### PR TITLE
fix: Fix the fixed qnn_dir path in linux sample of fcn_resnet50.py

### DIFF
--- a/samples/linux/python/fcn_resnet50/fcn_resnet50.py
+++ b/samples/linux/python/fcn_resnet50/fcn_resnet50.py
@@ -158,7 +158,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config("/home/ubuntu/code/ai-engine-direct-helper/qnn_libs", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for fcn_resnet50 objects.
     fcn_resnet50 = Fcn_resnet50("fcn_resnet50", model_path)


### PR DESCRIPTION
fix: Fix the fixed qnn_dir path in linux sample of fcn_resnet50.py

signed-off-by: "ZIFENG278" <zifengzhang18@gmail.com>