### PR TITLE
Remove qnn_dir and add chipset parser argument

### DIFF
--- a/samples/linux/python/convnext_base/convnext_base.py
+++ b/samples/linux/python/convnext_base/convnext_base.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 
 convnext_base = None
@@ -130,7 +117,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for convnext_base objects.
     convnext_base = Convnext_base("convnext_base", model_path)
@@ -164,7 +151,11 @@ def Release():
     # Release the resources.
     del(convnext_base)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -181,6 +172,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/convnext_tiny/convnext_tiny.py
+++ b/samples/linux/python/convnext_tiny/convnext_tiny.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 convnext_tiny = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for convnext_tiny objects.
     convnext_tiny = Convnext_tiny("convnext_tiny", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(convnext_tiny)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/efficientnet_b0/efficientnet_b0.py
+++ b/samples/linux/python/efficientnet_b0/efficientnet_b0.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -50,20 +50,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 efficientnet_b0 = None
 
@@ -130,7 +117,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for efficientnet_b0 objects.
     efficientnet_b0 = Efficientnet_b0("efficientnet_b0", model_path)
@@ -164,7 +151,11 @@ def Release():
     # Release the resources.
     del(efficientnet_b0)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -181,6 +172,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/efficientnet_b4/efficientnet_b4.py
+++ b/samples/linux/python/efficientnet_b4/efficientnet_b4.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 efficientnet_b4 = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for efficientnet_b4 objects.
     efficientnet_b4 = Efficientnet_b4("efficientnet_b4", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(efficientnet_b4)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/efficientnet_v2_s/efficientnet_v2_s.py
+++ b/samples/linux/python/efficientnet_v2_s/efficientnet_v2_s.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 efficientnet_v2_s = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for efficientnet_v2_s objects.
     efficientnet_v2_s = Efficientnet_v2_s("efficientnet_v2_s", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(efficientnet_v2_s)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/fcn_resnet50/fcn_resnet50.py
+++ b/samples/linux/python/fcn_resnet50/fcn_resnet50.py
@@ -26,12 +26,12 @@ IMAGE_SIZE = 520
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -44,20 +44,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 
 def resize_pad(
@@ -172,7 +159,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for fcn_resnet50 objects.
     fcn_resnet50 = Fcn_resnet50("fcn_resnet50", model_path)
@@ -234,7 +221,11 @@ def Release():
     # Release the resources.
     del(fcn_resnet50)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -254,6 +245,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/googlenet/googlenet.py
+++ b/samples/linux/python/googlenet/googlenet.py
@@ -30,16 +30,16 @@ IMAGE_SIZE=224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 
 # if not "python" in execution_ws:
-#     execution_ws = execution_ws + "\\" + "python"
+#     execution_ws = execution_ws + "/" + "python"
 
 # if not MODEL_NAME in execution_ws:
 #     execution_ws = execution_ws + "\\" + MODEL_NAME
@@ -53,20 +53,7 @@ INPUT_IMAGE_PATH_URL = "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/
 
 ###################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 googlenet=None
 
@@ -141,7 +128,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for GoogleNet objects.
     googlenet= GoogleNet("googlenet", model_path)
@@ -198,7 +185,11 @@ def Release():
     del(googlenet)
 
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         if not os.path.exists(input_image_path):
@@ -218,9 +209,10 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)
 
 
 

--- a/samples/linux/python/inception_v3/inception_v3.py
+++ b/samples/linux/python/inception_v3/inception_v3.py
@@ -32,15 +32,15 @@ IMAGE_SIZE = 224
 #execution_ws = os.getcwd()
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
-#     execution_ws = execution_ws + "\\" + "python"
+#     execution_ws = execution_ws + "/" + "python"
 
 if not MODEL_NAME in execution_ws:
     execution_ws = os.path.join(execution_ws , MODEL_NAME)
@@ -50,20 +50,7 @@ model_path = os.path.join(model_dir, MODEL_NAME + ".bin")
 print("model_path:",model_path)
 imagenet_classes_path = os.path.join(model_dir, IMAGENET_CLASSES_FILE)
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 ####################################################################
 
 inceptionV3 = None
@@ -131,7 +118,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for InceptionV3 objects.
     inceptionV3 = InceptionV3("inceptionV3", model_path)
@@ -165,7 +152,11 @@ def Release():
     # Release the resources.
     del(inceptionV3)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -182,6 +173,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/levit/levit.py
+++ b/samples/linux/python/levit/levit.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 levit = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for levit objects.
     levit = Levit("levit", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(levit)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/quicksrnetmedium/quicksrnetmedium.py
+++ b/samples/linux/python/quicksrnetmedium/quicksrnetmedium.py
@@ -36,14 +36,15 @@ IMAGE_SIZE = 128
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
-#     execution_ws = execution_ws + "\\" + "python"
+#     execution_ws = execution_ws + "/" + "python"
 
 # if not MODEL_NAME in execution_ws:
 #     execution_ws = execution_ws + "\\" + MODEL_NAME
@@ -56,20 +57,7 @@ input_image_path = os.path.join(execution_ws, "super_resolution_input.jpg")
 INPUT_IMAGE_PATH_URL = "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/super_resolution/v2/super_resolution_input.jpg"
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 image_buffer = None
 quicksrnetmedium = None
@@ -97,7 +85,7 @@ def Init():
     model_download()
     print("Init")
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for QuickSRNetMedium objects.
     quicksrnetmedium = QuickSRNetMedium("quicksrnetmedium", model_path)
@@ -143,8 +131,11 @@ def Release():
     # Release the resources.
     del(quicksrnetmedium)
 
-def main(input=None):
+def main(input=None, show_image=True, chipset="9075"):
+    global SOC_ID
 
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         if not os.path.exists(input_image_path):
@@ -153,13 +144,15 @@ def main(input=None):
         input = input_image_path
 
     Init()
-    Inference(input,os.path.join(execution_ws,"output.png"))
+    Inference(input, os.path.join(execution_ws,"output.png"), show_image=show_image)
 
     Release()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
     args = parser.parse_args()
-    main(args.image)
+    main(args.image, args.show_image, args.chipset)
     

--- a/samples/linux/python/real_esrgan_general_x4v3/real_esrgan_general_x4v3.py
+++ b/samples/linux/python/real_esrgan_general_x4v3/real_esrgan_general_x4v3.py
@@ -12,6 +12,7 @@ import cv2
 import numpy as np
 import torch
 import torchvision.transforms as transforms
+import argparse
 from PIL import Image
 from PIL.Image import fromarray as ImageFromArray
 
@@ -28,12 +29,12 @@ IMAGE_SIZE = 128
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -46,20 +47,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 image_buffer = None
 realesrgan = None
@@ -104,12 +92,12 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for RealESRGan objects.
     realesrgan = RealESRGan("realesrgan", model_path)
 
-def Inference(input_image_path, output_image_path):
+def Inference(input_image_path, output_image_path, show_image=True):
     global image_buffer
 
     # Read and preprocess the image.
@@ -133,7 +121,9 @@ def Inference(input_image_path, output_image_path):
     output_image = [torch_tensor_to_PIL_image(img) for img in output_image]
     image_buffer = output_image[0]
     image_buffer.save(output_image_path)
-    image_buffer.show()
+
+    if show_image:
+        image_buffer.show()
 
 def Release():
     global realesrgan
@@ -141,10 +131,30 @@ def Release():
     # Release the resources.
     del(realesrgan)
 
+def main(input_image_path=None, output_image_path=None, show_image=True, chipset="9075"):
+    global SOC_ID
 
-Init()
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
-Inference(os.path.join(execution_ws,"input.jpg"), os.path.join(execution_ws,"output.jpg"))
+    if input_image_path is None:
+        input_image_path = os.path.join(execution_ws, "input.jpg")
 
-Release()
+    if output_image_path is None:
+        output_image_path = os.path.join(execution_ws, "output.jpg")
 
+    Init()
+
+    Inference(input_image_path, output_image_path, show_image=show_image)
+
+    Release()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Process a single image path.")
+    parser.add_argument('--input_image_path', help='Path to the input image', default=None)
+    parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
+    args = parser.parse_args()
+
+    main(args.input_image_path, args.output_image_path, args.show_image, args.chipset)

--- a/samples/linux/python/real_esrgan_x4plus/real_esrgan_x4plus.py
+++ b/samples/linux/python/real_esrgan_x4plus/real_esrgan_x4plus.py
@@ -11,6 +11,7 @@ import utils.install as install
 import cv2
 import numpy as np
 import torchvision.transforms as transforms
+import argparse
 from PIL import Image
 from PIL.Image import fromarray as ImageFromArray
 from utils.image_processing import (
@@ -31,14 +32,15 @@ IMAGE_SIZE = 128
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
-#     execution_ws = execution_ws + "\\" + "python"
+#     execution_ws = execution_ws + "/" + "python"
 
 # if not MODEL_NAME in execution_ws:
 #     execution_ws = execution_ws + "\\" + MODEL_NAME
@@ -48,20 +50,7 @@ model_path = os.path.join(model_dir, MODEL_NAME + ".bin")
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 image_buffer = None
 realesrgan = None
@@ -90,7 +79,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for RealESRGan objects.
     realesrgan = RealESRGan("realesrgan", model_path,  deviceID = 0, coreIdsStr = "0")
@@ -136,9 +125,30 @@ def Release():
     # Release the resources.
     del(realesrgan)
 
-if __name__ == '__main__':
+def main(input_image_path=None, output_image_path=None, show_image=True, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
+
+    if input_image_path is None:
+        input_image_path = os.path.join(execution_ws, "input.jpg")
+
+    if output_image_path is None:
+        output_image_path = os.path.join(execution_ws, "output.jpg")
+
     Init()
 
-    Inference(os.path.join(execution_ws,"input.jpg"), os.path.join(execution_ws,"output.jpg"))
+    Inference(input_image_path, output_image_path, show_image=show_image)
 
     Release()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Process a single image path.")
+    parser.add_argument('--input_image_path', help='Path to the input image', default=None)
+    parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
+    args = parser.parse_args()
+
+    main(args.input_image_path, args.output_image_path, args.show_image, args.chipset)

--- a/samples/linux/python/regnet/regnet.py
+++ b/samples/linux/python/regnet/regnet.py
@@ -31,15 +31,15 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
-
-if not "python" in execution_ws:
-    execution_ws = execution_ws + "/" + "python"
+# if not "python" in execution_ws:
+#     execution_ws = execution_ws + "/" + "python"
 
 if not MODEL_NAME in execution_ws:
     execution_ws = execution_ws + "/" + MODEL_NAME
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 regnet = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for InceptionV3 objects.
     regnet = Regnet("regnet", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(regnet)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/sesr_m5/sesr_m5.py
+++ b/samples/linux/python/sesr_m5/sesr_m5.py
@@ -11,6 +11,7 @@ import utils.install as install
 import cv2
 import numpy as np
 import torchvision.transforms as transforms
+import argparse
 from PIL import Image
 from PIL.Image import fromarray as ImageFromArray
 from utils.image_processing import (
@@ -31,12 +32,12 @@ IMAGE_SIZE = 128
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -50,20 +51,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 image_buffer = None
 sesr_m5 = None
@@ -92,7 +80,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for sesr_m5 objects.
     sesr_m5 = Sesr_m5("sesr_m5", model_path)
@@ -140,9 +128,30 @@ def Release():
     # Release the resources.
     del(sesr_m5)
 
-if __name__ == '__main__':
+def main(input_image_path=None, output_image_path=None, show_image=True, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
+
+    if input_image_path is None:
+        input_image_path = os.path.join(execution_ws, "input.jpg")
+
+    if output_image_path is None:
+        output_image_path = os.path.join(execution_ws, "output.jpg")
+
     Init()
 
-    Inference(os.path.join(execution_ws,"input.jpg"), os.path.join(execution_ws,"output.jpg"))
+    Inference(input_image_path, output_image_path, show_image=show_image)
 
     Release()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Process a single image path.")
+    parser.add_argument('--input_image_path', help='Path to the input image', default=None)
+    parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
+    args = parser.parse_args()
+
+    main(args.input_image_path, args.output_image_path, args.show_image, args.chipset)

--- a/samples/linux/python/shufflenet_v2/shufflenet_v2.py
+++ b/samples/linux/python/shufflenet_v2/shufflenet_v2.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 shufflenet_v2 = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # shufflenet_v2 for InceptionV3 objects.
     shufflenet_v2 = Shufflenet_v2("shufflenet_v2", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(shufflenet_v2)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/squeezenet1_1/squeezenet1_1.py
+++ b/samples/linux/python/squeezenet1_1/squeezenet1_1.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 squeezenet1_1 = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # squeezenet1_1 for InceptionV3 objects.
     squeezenet1_1 = Squeezenet1_1("squeezenet1_1", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(squeezenet1_1)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/vit/vit.py
+++ b/samples/linux/python/vit/vit.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 vit = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # swin_small for InceptionV3 objects.
     vit = Vit("vit", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(vit)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/wideresnet50/wideresnet50.py
+++ b/samples/linux/python/wideresnet50/wideresnet50.py
@@ -31,12 +31,12 @@ IMAGE_SIZE = 224
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -49,20 +49,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 imagenet_classes_path = model_dir + "/" + IMAGENET_CLASSES_FILE
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 wideresnet50 = None
 
@@ -129,7 +116,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # swin_small for InceptionV3 objects.
     wideresnet50 = Wideresnet50("wideresnet50", model_path)
@@ -163,7 +150,11 @@ def Release():
     # Release the resources.
     del(wideresnet50)
 
-def main(input = None):
+def main(input = None, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input is None:
         input = os.path.join(execution_ws, "input.jpg")
@@ -180,6 +171,7 @@ def main(input = None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--image', help='Path to the image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
     args = parser.parse_args()
 
-    main(args.image)
+    main(args.image, args.chipset)

--- a/samples/linux/python/xlsr/xlsr.py
+++ b/samples/linux/python/xlsr/xlsr.py
@@ -11,6 +11,7 @@ import utils.install as install
 import cv2
 import numpy as np
 import torchvision.transforms as transforms
+import argparse
 from PIL import Image
 from PIL.Image import fromarray as ImageFromArray
 from utils.image_processing import (
@@ -31,12 +32,12 @@ IMAGE_SIZE = 128
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -50,20 +51,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 image_buffer = None
 xlsr = None
@@ -92,7 +80,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for xlsr objects.
     xlsr = Xlsr("xlsr", model_path)
@@ -138,9 +126,30 @@ def Release():
     # Release the resources.
     del(xlsr)
 
-if __name__ == '__main__':
+def main(input_image_path=None, output_image_path=None, show_image=True, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
+
+    if input_image_path is None:
+        input_image_path = os.path.join(execution_ws, "input.jpg")
+
+    if output_image_path is None:
+        output_image_path = os.path.join(execution_ws, "output.jpg")
+
     Init()
 
-    Inference(os.path.join(execution_ws,"input.jpg"), os.path.join(execution_ws,"output.jpg"))
+    Inference(input_image_path, output_image_path, show_image=show_image)
 
     Release()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Process a single image path.")
+    parser.add_argument('--input_image_path', help='Path to the input image', default=None)
+    parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
+    args = parser.parse_args()
+
+    main(args.input_image_path, args.output_image_path, args.show_image, args.chipset)

--- a/samples/linux/python/yolo26n_det/yolo26n_det.py
+++ b/samples/linux/python/yolo26n_det/yolo26n_det.py
@@ -31,31 +31,18 @@ IMAGE_SIZE = 640
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 model_path = "<path to your yolo26 series qnn model>"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 yolo26n = None
 
@@ -221,7 +208,7 @@ def Init():
     global yolo26
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for Yolo26 objects.
     yolo26 = Yolo26("yolo26", model_path)
@@ -294,7 +281,11 @@ def Release():
     del(yolo26)
 
 
-def main(input_image_path=None, output_image_path=None, show_image=False, confidence: float = 0.80):
+def main(input_image_path=None, output_image_path=None, show_image=False, confidence: float = 0.80, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input_image_path is None:
         input_image_path = os.path.join(execution_ws, "input.jpg")
@@ -321,6 +312,8 @@ if __name__ == '__main__':
     #input_image_path, output_image_path
     parser.add_argument('--output_image_path', help='Path to the output image', default=None)
     parser.add_argument('--confidence', help='Score threshold for keeping boxes', type=float, default=0.60)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=False, help='Show the output image')
     args = parser.parse_args()
 
-    main(args.input_image_path, args.output_image_path, confidence=args.confidence)
+    main(args.input_image_path, args.output_image_path, args.show_image, args.confidence, args.chipset)

--- a/samples/linux/python/yolov8_det/yolov8_det.py
+++ b/samples/linux/python/yolov8_det/yolov8_det.py
@@ -32,12 +32,12 @@ IMAGE_SIZE = 640
 
 execution_ws=os.path.dirname(os.path.abspath(__file__))
 print(f"Current file directory: {execution_ws}")
-qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
-if not qnn_sdk_root:
-    print("Error: QNN_SDK_ROOT environment variable is not set.")
-    sys.exit(1)
-
-qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
+# qnn_sdk_root = os.environ.get("QNN_SDK_ROOT")
+# if not qnn_sdk_root:
+#     print("Error: QNN_SDK_ROOT environment variable is not set.")
+#     sys.exit(1)
+#
+# qnn_dir = os.path.join(qnn_sdk_root, "lib/aarch64-oe-linux-gcc11.2")
 
 # if not "python" in execution_ws:
 #     execution_ws = execution_ws + "/" + "python"
@@ -50,20 +50,7 @@ model_path = model_dir + "/" + MODEL_NAME + ".bin"
 
 ####################################################################
 
-SOC_ID = None
-cleaned_argv = []
-i = 0
-while i < len(sys.argv):
-    if sys.argv[i] == '--chipset':
-        SOC_ID = sys.argv[i + 1]
-        i += 2
-    else:
-        cleaned_argv.append(sys.argv[i])
-        i += 1
-
-sys.argv = cleaned_argv
-
-print(f"SOC_ID: {SOC_ID}")
+SOC_ID = "9075"
 
 yolov8 = None
 
@@ -322,7 +309,7 @@ def Init():
     model_download()
 
     # Config AppBuilder environment.
-    QNNConfig.Config(qnn_dir, Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
+    QNNConfig.Config("None", Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
 
     # Instance for YoloV8 objects.
     yolov8 = YoloV8("yolov8", model_path)
@@ -400,7 +387,11 @@ def Release():
     del(yolov8)
 
 
-def main(input_image_path=None, output_image_path=None, show_image=True):
+def main(input_image_path=None, output_image_path=None, show_image=True, chipset="9075"):
+    global SOC_ID
+
+    SOC_ID = chipset
+    print(f"SOC_ID: {SOC_ID}")
 
     if input_image_path is None:
         input_image_path = os.path.join(execution_ws, "input.jpg")
@@ -421,6 +412,8 @@ if __name__ == '__main__':
     parser.add_argument('--input_image_path', help='Path to the input image', default=None)
     #input_image_path, output_image_path
     parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument('--chipset', choices=["6490", "9075"], default="9075", help='Target chipset')
+    parser.add_argument('--show_image', action=argparse.BooleanOptionalAction, default=True, help='Show the output image')
     args = parser.parse_args()
 
-    main(args.input_image_path, args.output_image_path)
+    main(args.input_image_path, args.output_image_path, args.show_image, args.chipset)


### PR DESCRIPTION
1. after QAI-APPBUILDER v2..0.0, qnn_dir do not need to set, so remove the qnn_dir to avoid program exit
2. add chipset parser argument to avoid use v73 model on v68 platform 