### PR TITLE
Lock sg_model_map to make QnnSampleApp pool access thread-safe

### DIFF
--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <chrono>
 #include <unordered_map>
+#include <mutex>
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,6 +54,13 @@ static bool gs_isGpu = false;
 static bool sg_perf_global = false;
 
 std::unordered_map<std::string, std::unique_ptr<sample_app::QnnSampleApp>> sg_model_map;
+// Guards sg_model_map only. The map is mutated (erase on take, insert on
+// return) by every ModelInference/ModelInitialize call. When two pipeline
+// threads run different models concurrently (e.g. model a on HTP0 + model 1 on HTP1),
+// their erase/insert on this shared map race and corrupt its bucket list.
+// This mutex serializes ONLY the map find/erase/insert; executeGraphsBuffers
+// (the actual HTP inference) runs OUTSIDE the lock, so parallelism is kept.
+static std::mutex sg_model_map_mutex;
 static sample_app::ProfilingLevel sg_parsedProfilingLevel = sample_app::ProfilingLevel::OFF;
 
 namespace qnn {
@@ -155,6 +163,7 @@ std::unique_ptr<sample_app::QnnSampleApp> initQnnSampleApp(std::string cachedBin
 
 
 std::unique_ptr<sample_app::QnnSampleApp> getQnnSampleApp(std::string model_name) {
+  std::lock_guard<std::mutex> lk(sg_model_map_mutex);
   auto it = sg_model_map.find(model_name);
   if (it != sg_model_map.end()) {
     if (it->second) {
@@ -164,6 +173,15 @@ std::unique_ptr<sample_app::QnnSampleApp> getQnnSampleApp(std::string model_name
     }
   }
   return nullptr;
+}
+
+// Symmetric counterpart to getQnnSampleApp: re-insert the app under the same
+// lock. Replaces the bare `sg_model_map.insert(...)` calls scattered across
+// ModelInference/ModelInitialize so every map mutation is serialized.
+void putQnnSampleApp(std::string model_name,
+                     std::unique_ptr<sample_app::QnnSampleApp> app) {
+  std::lock_guard<std::mutex> lk(sg_model_map_mutex);
+  sg_model_map.insert(std::make_pair(std::move(model_name), std::move(app)));
 }
 
 void SetProcInfo(std::string proc_name, uint64_t epoch) {
@@ -573,7 +591,7 @@ bool ModelInitializeEx(const std::string& model_name, const std::string& proc_na
 
     timerHelper.Print("model_initialize " + model_name);
 
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
 
     return true;
   }
@@ -611,7 +629,7 @@ bool ModelInferenceEx(std::string model_name, std::string proc_name, std::string
         result = false;
     }
 
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
 
     timerHelper.Print("model_inference " + model_name);
 
@@ -742,7 +760,7 @@ bool LibAppBuilder::ModelApplyBinaryUpdate(const std::string model_name, std::ve
     
     }
 
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
 
     return result;
 }
@@ -780,49 +798,49 @@ bool LibAppBuilder::DeleteShareMemory(std::string share_memory_name) {
 std::vector<std::vector<size_t>> LibAppBuilder::getOutputShapes(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_outputShapes = app->getOutputShapes();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_outputShapes;
 };
 
 std::vector<std::vector<size_t>> LibAppBuilder::getInputShapes(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_inputShapes = app->getInputShapes();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_inputShapes;
 };
 
 std::vector<std::string> LibAppBuilder::getInputDataType(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_inputDataType = app->getInputDataType();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_inputDataType;
 };
 
 std::vector<std::string> LibAppBuilder::getOutputDataType(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_outputDataType = app->getOutputDataType();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_outputDataType;
 };
 
 std::string LibAppBuilder::getGraphName(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_graphName = app->getGraphName();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_graphName;
 };
 
 std::vector<std::string> LibAppBuilder::getInputName(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_inputName = app->getInputName();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_inputName;
 };
 
 std::vector<std::string> LibAppBuilder::getOutputName(std::string model_name){
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     m_outputName = app->getOutputName();
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return m_outputName;
 };
 //proc
@@ -905,7 +923,7 @@ ModelInfo_t LibAppBuilder::getModelInfoExt(std::string model_name, std::string i
             return info;
         }
     }
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
 
     return info;
 }
@@ -914,7 +932,7 @@ uint64_t LibAppBuilder::getProfilingEvent(std::string model_name, uint32_t event
     uint64_t eventValue;
     std::unique_ptr<sample_app::QnnSampleApp> app = getQnnSampleApp(model_name);
     eventValue = app->getProfilingEvent(eventType);
-    sg_model_map.insert(std::make_pair(model_name, std::move(app)));
+    putQnnSampleApp(model_name, std::move(app));
     return eventValue;
 }
 


### PR DESCRIPTION
**Simultaneous access to sg_model_map by multiple threads can cause a data race, so I think it needs to be protected by a mutex.**

**Background**
I am running two threads on the IQ-9075, each using a different HTP device to run inference for model A and model B respectively, and I encountered the following segfault:

`Caught signal 11 (segfault). Backtrace:
./cpp_pipeline/build/musetalk_cpp(+0x71ec)[0xaaaae90c71ec]
linux-vdso.so.1(__kernel_rt_sigreturn+0x0)[0xffffa141078c]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4sizeEv+0xc)[0xffffa12fead8]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZSteqIcSt11char_traitsIcESaIcEEbRKNSt7__cxx1112basic_stringIT_T0_T1_EESA_+0x28)[0xffffa1300de8]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZNKSt8equal_toINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEclERKS5_S8_+0x20)[0xffffa1310c74]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZNKSt8__detail15_Hashtable_baseINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS6_St10unique_ptrIN3qnn5tools10sample_app12QnnSampleAppESt14default_deleteISD_EEENS_10_Select1stESt8equal_toIS6_ESt4hashIS6_ENS_18_Mod_range_hashingENS_20_Default_ranged_hashENS_17_Hashtable_traitsILb1ELb0ELb1EEEE13_M_key_equalsERS8_RKNS_16_Hash_node_valueISH_Lb1EEE+0x78)[0xffffa137445c]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZNSt10_HashtableINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_St10unique_ptrIN3qnn5tools10sample_app12QnnSampleAppESt14default_deleteISC_EEESaISG_ENSt8__detail10_Select1stESt8equal_toIS5_ESt4hashIS5_ENSI_18_Mod_range_hashingENSI_20_Default_ranged_hashENSI_20_Prime_rehash_policyENSI_17_Hashtable_traitsILb1ELb0ELb1EEEE4findERS7_+0x7c)[0xffffa13739bc]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZNSt13unordered_mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt10unique_ptrIN3qnn5tools10sample_app12QnnSampleAppESt14default_deleteISA_EESt4hashIS5_ESt8equal_toIS5_ESaISt4pairIKS5_SD_EEE4findERSJ_+0x1c)[0xffffa1373200]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_Z15getQnnSampleAppNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x3c)[0xffffa136d71c]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_Z16ModelInferenceExNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES4_S4_RSt6vectorIPhSaIS6_EERS5_ImSaImEES9_SC_RS4_mm+0x70)[0xffffa136fb80]
/home/radxa/miniconda3/envs/qai_appbuilder/lib/python3.12/site-packages/qai_appbuilder/libappbuilder.so(_ZN13LibAppBuilder14ModelInferenceENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIPhSaIS7_EESA_RS6_ImSaImEERS5_mm+0xec)[0xffffa13707f4]
./cpp_pipeline/build/musetalk_cpp(+0xf9a8)[0xaaaae90cf9a8]
./cpp_pipeline/build/musetalk_cpp(+0x1b848)[0xaaaae90db848]
/lib/aarch64-linux-gnu/libstdc++.so.6(+0xe1ae0)[0xffffa0811ae0]
/lib/aarch64-linux-gnu/libc.so.6(+0x8595c)[0xffffa050595c]
/lib/aarch64-linux-gnu/libc.so.6(+0xebb0c)[0xffffa056bb0c]
`