### PR TITLE
fix: correct self.m_context = None in _QNNContextBase.__del__

### DIFF
--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -265,7 +265,7 @@ class _QNNContextBase:
     def __del__(self):
         if hasattr(self, "m_context") and self.m_context is not None:
             del (self.m_context)
-        m_context = None
+        self.m_context = None
 
 
 class QNNContext(_QNNContextBase):


### PR DESCRIPTION
Closes #99

## Summary

The `__del__` method in `_QNNContextBase` had a typo: it assigned `m_context = None` (a local variable) instead of `self.m_context = None` (the instance attribute). After `del(self.m_context)`, the instance attribute was left dangling until garbage collection.

## Change

```python
# Before
def __del__(self):
    if hasattr(self, "m_context") and self.m_context is not None:
        del (self.m_context)
    m_context = None  # bug: local variable, not self.m_context

# After
def __del__(self):
    if hasattr(self, "m_context") and self.m_context is not None:
        del (self.m_context)
    self.m_context = None  # fix: assign to instance attribute
```