### PR TITLE
ci: GitHub Actions CI/CD pipeline + 4 source-level fixes

### DIFF
--- a/.github/actions/setup-qnn-sdk/action.yml
+++ b/.github/actions/setup-qnn-sdk/action.yml
@@ -1,0 +1,318 @@
+name: 'Setup QNN SDK'
+description: >
+  Download and cache the Qualcomm AI Runtime Community SDK,
+  then expose QNN_SDK_ROOT for downstream steps. Supports Windows
+  and Linux hosted runners.
+
+inputs:
+  version:
+    description: 'QNN Community SDK version (matches the URL path).'
+    required: false
+    default: '2.47.0.260601'
+  url:
+    description: 'Override the SDK download URL. Defaults to the Community SDK matching `version`.'
+    required: false
+    default: ''
+  genie-runtime-url:
+    description: >
+      URL of the QAIRT zip that contains the customized Genie.dll/lib to
+      overlay onto the Community SDK on Windows. The zip is expected to
+      contain `arm64x-windows-msvc/Genie.{dll,lib}` (x64 + ARM64EC host
+      processes) and `aarch64-windows-msvc/Genie.{dll,lib}` (native
+      ARM64 processes). Linux and Android jobs do not consume this — the
+      customized Genie is Windows-only, so non-Windows builds always use
+      the Genie shipped in the QNN SDK as-is (do not pass this input
+      from Linux/Android callers).
+
+      Empty value disables the overlay (the build uses the SDK-bundled
+      Genie unchanged).
+    required: false
+    default: ''
+  genie-runtime-version:
+    description: 'Version label used in the Genie zip cache key. Bump together with genie-runtime-url.'
+    required: false
+    default: ''
+
+outputs:
+  qnn-sdk-root:
+    description: 'Absolute path to the extracted QNN SDK (also exported as QNN_SDK_ROOT).'
+    value: ${{ steps.expose-windows.outputs.qnn-sdk-root || steps.expose-linux.outputs.qnn-sdk-root }}
+
+runs:
+  using: 'composite'
+  steps:
+    # -----------------------------------------------------------------
+    # Resolve URL and install dir (OS-agnostic; written in pwsh because
+    # GitHub-hosted ubuntu runners ship pwsh preinstalled).
+    # -----------------------------------------------------------------
+    - name: Resolve SDK URL and install dir (Windows)
+      id: vars-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $version = "${{ inputs.version }}"
+        $url = "${{ inputs.url }}"
+        if ([string]::IsNullOrEmpty($url)) {
+          $url = "https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/$version/v$version.zip"
+        }
+        $installDir = Join-Path $env:RUNNER_TEMP "qnn-sdk-$version"
+        "url=$url"               | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "install-dir=$installDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Resolve SDK URL and install dir (Linux)
+      id: vars-linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        version="${{ inputs.version }}"
+        url="${{ inputs.url }}"
+        if [ -z "$url" ]; then
+          url="https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/${version}/v${version}.zip"
+        fi
+        install_dir="${RUNNER_TEMP}/qnn-sdk-${version}"
+        echo "url=${url}" >> "$GITHUB_OUTPUT"
+        echo "install-dir=${install_dir}" >> "$GITHUB_OUTPUT"
+
+    # -----------------------------------------------------------------
+    # Cache (single step; path/key resolved per-OS via the two steps above).
+    # -----------------------------------------------------------------
+    - name: Restore QNN SDK from cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.vars-windows.outputs.install-dir || steps.vars-linux.outputs.install-dir }}
+        key: qnn-sdk-${{ inputs.version }}-${{ runner.os }}-v1
+
+    # -----------------------------------------------------------------
+    # Download + extract — OS-specific so .so permissions survive on Linux.
+    # -----------------------------------------------------------------
+    - name: Download and extract QNN SDK (Windows)
+      if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $url        = "${{ steps.vars-windows.outputs.url }}"
+        $installDir = "${{ steps.vars-windows.outputs.install-dir }}"
+        $zipPath    = Join-Path $env:RUNNER_TEMP "qnn-sdk.zip"
+
+        Write-Host "Downloading QNN SDK from $url"
+        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing
+        Write-Host "Extracting to $installDir"
+        New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+        Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+        Remove-Item $zipPath -Force
+
+    - name: Download and extract QNN SDK (Linux)
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        url="${{ steps.vars-linux.outputs.url }}"
+        install_dir="${{ steps.vars-linux.outputs.install-dir }}"
+        zip_path="${RUNNER_TEMP}/qnn-sdk.zip"
+
+        echo "Downloading QNN SDK from $url"
+        curl -fsSL "$url" -o "$zip_path"
+        echo "Extracting to $install_dir"
+        mkdir -p "$install_dir"
+        unzip -q "$zip_path" -d "$install_dir"
+        rm -f "$zip_path"
+
+    # -----------------------------------------------------------------
+    # Locate QNN_SDK_ROOT — also OS-specific because of path / probe syntax.
+    # -----------------------------------------------------------------
+    - name: Locate QNN SDK root and export (Windows)
+      id: expose-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $installDir = "${{ steps.vars-windows.outputs.install-dir }}"
+
+        $candidates = @(
+          $installDir,
+          (Join-Path $installDir "qairt"),
+          (Join-Path $installDir "qairt/${{ inputs.version }}")
+        )
+        $sdkRoot = $null
+        foreach ($c in $candidates) {
+          if ((Test-Path (Join-Path $c "lib")) -and (Test-Path (Join-Path $c "include"))) {
+            $sdkRoot = (Resolve-Path $c).Path
+            break
+          }
+        }
+        if (-not $sdkRoot) {
+          Get-ChildItem $installDir -Directory | ForEach-Object {
+            if (-not $sdkRoot -and (Test-Path (Join-Path $_.FullName "lib"))) {
+              $sdkRoot = $_.FullName
+            }
+            if (-not $sdkRoot) {
+              Get-ChildItem $_.FullName -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+                if (-not $sdkRoot -and (Test-Path (Join-Path $_.FullName "lib"))) {
+                  $sdkRoot = $_.FullName
+                }
+              }
+            }
+          }
+        }
+        if (-not $sdkRoot) {
+          Write-Host "Failed to locate QNN SDK root under $installDir. Tree:"
+          Get-ChildItem $installDir -Recurse -Depth 2 | Select-Object FullName
+          exit 1
+        }
+
+        Write-Host "QNN_SDK_ROOT = $sdkRoot"
+        Write-Host "Contents of lib/:"
+        Get-ChildItem (Join-Path $sdkRoot "lib") | Select-Object Name
+
+        "qnn-sdk-root=$sdkRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        "QNN_SDK_ROOT=$sdkRoot" | Out-File -FilePath $env:GITHUB_ENV    -Append -Encoding utf8
+
+    - name: Locate QNN SDK root and export (Linux)
+      id: expose-linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        install_dir="${{ steps.vars-linux.outputs.install-dir }}"
+        version="${{ inputs.version }}"
+
+        sdk_root=""
+        for c in "$install_dir" "$install_dir/qairt" "$install_dir/qairt/$version"; do
+          if [ -d "$c/lib" ] && [ -d "$c/include" ]; then
+            sdk_root="$(cd "$c" && pwd)"
+            break
+          fi
+        done
+
+        if [ -z "$sdk_root" ]; then
+          # Fallback: scan one or two levels deep for a dir containing lib/.
+          while IFS= read -r d; do
+            if [ -d "$d/lib" ]; then sdk_root="$d"; break; fi
+          done < <(find "$install_dir" -mindepth 1 -maxdepth 2 -type d 2>/dev/null)
+        fi
+
+        if [ -z "$sdk_root" ]; then
+          echo "Failed to locate QNN SDK root under $install_dir. Tree:"
+          find "$install_dir" -maxdepth 3 -type d
+          exit 1
+        fi
+
+        echo "QNN_SDK_ROOT = $sdk_root"
+        echo "Contents of lib/:"
+        ls -1 "$sdk_root/lib"
+
+        echo "qnn-sdk-root=$sdk_root" >> "$GITHUB_OUTPUT"
+        echo "QNN_SDK_ROOT=$sdk_root" >> "$GITHUB_ENV"
+
+    # -----------------------------------------------------------------
+    # Genie overlay — replace the upstream Genie shipped in the Community
+    # SDK with the quic-customized Genie from QAIRT_Runtime_*_v73.zip.
+    # BUILD.md mandates this; samples/genie/ depends on the customized
+    # symbols. Until matching 2.46/2.47 builds of the customized zip
+    # exist, this is stubbed at the v2.38.0 zip — close enough to make
+    # the build/import path produce something, but Genie behavior may
+    # diverge until upstream zips for 2.46/2.47 land.
+    # -----------------------------------------------------------------
+    - name: Resolve Genie overlay paths and cache key (Windows)
+      id: genie-vars-windows
+      if: runner.os == 'Windows' && inputs.genie-runtime-url != ''
+      shell: pwsh
+      run: |
+        $stage = Join-Path $env:RUNNER_TEMP "qairt-runtime-${{ inputs.genie-runtime-version }}"
+        "stage-dir=$stage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+    - name: Restore Genie overlay from cache
+      id: genie-cache
+      if: runner.os == 'Windows' && inputs.genie-runtime-url != ''
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.genie-vars-windows.outputs.stage-dir }}
+        key: genie-runtime-${{ inputs.genie-runtime-version }}-${{ runner.os }}-v1
+
+    - name: Download Genie overlay (Windows)
+      if: runner.os == 'Windows' && inputs.genie-runtime-url != '' && steps.genie-cache.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $url   = "${{ inputs.genie-runtime-url }}"
+        $stage = "${{ steps.genie-vars-windows.outputs.stage-dir }}"
+        $zip   = Join-Path $env:RUNNER_TEMP "qairt-runtime.zip"
+
+        Write-Host "Downloading Genie overlay from $url"
+        Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+        New-Item -ItemType Directory -Force -Path $stage | Out-Null
+        Expand-Archive -Path $zip -DestinationPath $stage -Force
+        Remove-Item $zip -Force
+
+    - name: Apply Genie overlay (Windows)
+      if: runner.os == 'Windows' && inputs.genie-runtime-url != ''
+      shell: pwsh
+      # Per BUILD.md: copy Genie.dll/Genie.lib from the overlay zip's
+      # arm64x-windows-msvc/ and aarch64-windows-msvc/ subdirs into the
+      # SDK's same-named lib subdirs. Also copy the GenieDialog.h header
+      # if present. We tolerate missing source files (the v2.38.0 stub
+      # may not match every layout) so this is best-effort with a clear
+      # log of what got copied.
+      run: |
+        $stage = "${{ steps.genie-vars-windows.outputs.stage-dir }}"
+        $sdk   = $env:QNN_SDK_ROOT
+
+        # The overlay zip extracts as either:  <stage>/QAIRT_Runtime_*/...  or
+        # directly  <stage>/arm64x-windows-msvc/...  Probe for it.
+        $overlayRoot = $null
+        if ((Test-Path (Join-Path $stage "arm64x-windows-msvc")) -or
+            (Test-Path (Join-Path $stage "aarch64-windows-msvc"))) {
+          $overlayRoot = $stage
+        } else {
+          Get-ChildItem $stage -Directory | ForEach-Object {
+            if (-not $overlayRoot -and (
+                (Test-Path (Join-Path $_.FullName "arm64x-windows-msvc")) -or
+                (Test-Path (Join-Path $_.FullName "aarch64-windows-msvc"))
+              )) {
+              $overlayRoot = $_.FullName
+            }
+          }
+        }
+        if (-not $overlayRoot) {
+          Write-Host "::warning::Genie overlay zip layout not recognized under $stage. Skipping overlay (build will use upstream Genie). Tree:"
+          Get-ChildItem $stage -Recurse -Depth 2 | Select-Object FullName
+          exit 0
+        }
+
+        Write-Host "Genie overlay root: $overlayRoot"
+        Write-Host "QNN_SDK_ROOT      : $sdk"
+
+        $copied = @()
+        foreach ($abi in @("arm64x-windows-msvc", "aarch64-windows-msvc")) {
+          $src = Join-Path $overlayRoot $abi
+          $dst = Join-Path $sdk         "lib/$abi"
+          if (-not (Test-Path $src)) { continue }
+          if (-not (Test-Path $dst)) {
+            Write-Host "::warning::SDK lib subdir $dst not present; skipping $abi overlay"
+            continue
+          }
+          foreach ($name in @("Genie.dll", "Genie.lib")) {
+            $s = Join-Path $src $name
+            if (Test-Path $s) {
+              Copy-Item $s (Join-Path $dst $name) -Force
+              $copied += "$abi/$name"
+            }
+          }
+        }
+
+        # Optional header
+        $hdr = Get-ChildItem $overlayRoot -Recurse -Filter "GenieDialog.h" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($hdr) {
+          $dstHdrDir = Join-Path $sdk "include/Genie"
+          if (-not (Test-Path $dstHdrDir)) {
+            $dstHdrDir = Join-Path $sdk "include/QNN"
+          }
+          if (Test-Path $dstHdrDir) {
+            Copy-Item $hdr.FullName (Join-Path $dstHdrDir "GenieDialog.h") -Force
+            $copied += "include/$(Split-Path $dstHdrDir -Leaf)/GenieDialog.h"
+          }
+        }
+
+        if ($copied.Count -eq 0) {
+          Write-Host "::warning::No Genie files were copied. Build will use the SDK's bundled Genie."
+        } else {
+          Write-Host "Genie overlay applied ($($copied.Count) files):"
+          $copied | ForEach-Object { Write-Host "  $_" }
+        }
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,9 +518,9 @@ jobs:
         # bundled (upstream) Genie. Fill in the URL for any row once an
         # overlay zip is published for that version.
         qnn:
-          - version: '2.40.1.251119'
-            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.40.1.251119/v2.40.1.251119.zip'
-            genie-url: ''
+          # 2.40.1.251119 dropped — its Community SDK zip is no longer
+          # hosted at apigwx-aws.qualcomm.com (HTTP 404 / S3 NoSuchKey).
+          # Restore the entry if the URL becomes available again.
           - version: '2.41.0.251128'
             url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.41.0.251128/v2.41.0.251128.zip'
             genie-url: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,924 @@
+name: CI
+
+# Stage A scope (current):
+#   - lint (Ubuntu, GitHub-hosted, informational only)
+#   - build the windows-x64 wheel (ARM64EC binaries, for x64 Python on X Elite)
+#       on windows-latest. Cannot smoke-test it here because windows-latest is
+#       x86-64 hardware and ARM64EC binaries crash on import (access violation).
+#       Smoke test for this wheel happens on real X Elite hardware in Stage B.
+#   - build the windows-arm64 wheel (native aarch64) on windows-11-arm and
+#       smoke-test it natively (the runner IS ARM64, so import works).
+#   - build the linux-aarch64 wheel on ubuntu-22.04-arm and smoke-test it.
+#   - build android arm64-v8a libappbuilder.so via NDK r26d (no testing
+#     because exercising the .so needs an Android device).
+#   - build samples/genie/c++/Service (GenieAPIService) on windows-2022
+#     cross-compiled to ARM64, per samples/genie/c++/docs/BUILD.md. Pulls
+#     ~11 genie/c++/External/* submodules (llama.cpp, MNN, curl, ...).
+#     USE_MNN/USE_GGUF currently OFF on hosted runners — re-enable once
+#     the toolchain story is sorted out (see ci-stage-a history).
+#   - build samples/genie/c++/Service for Linux ARM64 (ubuntu-22.04-arm)
+#     via the project-provided build_linux.sh.
+#   - build samples/genie/c++/Service for Android arm64-v8a (windows-2022
+#     + NDK r26d) via the project-provided build_android.bat. APK signing
+#     step is best-effort (no signing secrets configured).
+#
+# Release: pushing a `v*` tag (e.g. `git tag v2.47.0 && git push --tags`)
+# additionally triggers the `release` job, which gathers every build
+# artifact and publishes a GitHub Release at that tag.
+#
+# Matrix:
+#   - Windows x64 + Windows ARM64: 3 Python (3.11/3.12/3.13) x 2 QNN SDK
+#       (2.46/2.47) per OS = 12 jobs total across both Windows OSes
+#   - Linux aarch64: 1 job (py3.12 x QNN 2.47), expanded once stable
+#
+# fail-fast disabled so a single broken combination does not mask the rest.
+#
+# Smoke tests (windows-arm64 + linux-aarch64):
+#   tests/test_package_smoke.py       — pure-Python imports + constants
+#   tests/test_cpu_runtime_smoke.py   — pybind C++ extension + QNN CPU
+#                                       backend DLL/so discovery (no NPU)
+#
+# Known limitation: the Community SDK ships an upstream Genie. The Genie
+# library bundled into the wheel will be the upstream one rather than the
+# customized build referenced in BUILD.md. Smoke tests do not exercise Genie.
+# NPU end-to-end + Genie LLM tests live in Stage B (self-hosted X Elite
+# runner) and are not part of this workflow.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+# Opt every step into the Node 24 runtime for JavaScript actions.
+# Node 20 is being phased out on GitHub-hosted runners (forced 2026-06-16,
+# removed 2026-09-16) and the warning shows up across actions/checkout,
+# actions/cache, actions/upload-artifact, etc. Setting this once at the
+# workflow level avoids version-bump churn on each action reference.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    # Informational only while pre-existing lint debt is paid down in a
+    # separate cleanup. Findings still appear in the job log; they do not
+    # gate the build/test path. Flip continue-on-error to false once the
+    # baseline is clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff==0.6.9
+
+      - name: Run ruff
+        run: ruff check script/ tests/ samples/python/utils/
+
+  build-windows-x64:
+    name: x64 wheel · py${{ matrix.python }} · qnn${{ matrix.qnn.version }}
+    # Pin to windows-2022 explicitly. windows-latest is migrating to
+    # windows-2025; during the rollover, CMake's VS-instance discovery
+    # ("could not find any instance of Visual Studio") gets flaky.
+    runs-on: windows-2022
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12', '3.13']
+        qnn:
+          # Single SDK row for now. To add another version, copy this block.
+          # genie-url points at the customized Genie zip published by the
+          # qualcomm/qai-appbuilder release; setup-qnn-sdk extracts it and
+          # overlays Genie.dll / Genie.lib (+ headers + libGenie.so for Linux)
+          # onto the Community SDK. Leave empty to skip the overlay.
+          - version: '2.47.0.260601'
+            url: ''
+            genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
+          # 2.46 enabled with SDK-bundled Genie only — no matching
+          # customized Genie zip is published on qualcomm/qai-appbuilder
+          # yet. Add the genie-url when that ships.
+          - version: '2.46.0.260424'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.46.0.260424/v2.46.0.260424.zip'
+            genie-url: ''
+    steps:
+      - name: Checkout (with pybind11 submodule only)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init pybind11 submodule
+        shell: pwsh
+        run: |
+          git submodule update --init --depth 1 pybind/pybind11
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: 'x64'
+
+      # Explicitly stage MSVC for the amd64 host -> arm64 target cross
+      # toolchain. CMake's VS-instance discovery has been flaky on the
+      # windows-latest -> windows-2025 transition; running vcvarsall up
+      # front and exporting its env via GITHUB_ENV makes the build
+      # robust to that. ARM64EC binaries link against the ARM64 toolset
+      # so amd64_arm64 is the correct vcvars arch.
+      - name: Setup MSVC (amd64_arm64)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: ${{ matrix.qnn.version }}
+          url: ${{ matrix.qnn.url }}
+          genie-runtime-url: ${{ matrix.qnn.genie-url }}
+          genie-runtime-version: ${{ matrix.qnn.version }}_v73
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel==0.45.1 setuptools==80.9.0 pybind11==2.13.6 build==1.4.0 "cmake>=3.21"
+
+      - name: Build wheel
+        shell: pwsh
+        env:
+          QAI_TOOLCHAINS: arm64x-windows-msvc
+          QAI_HEXAGONARCH: '81'
+        run: |
+          python -m build -w --no-isolation
+
+      - name: List wheel contents
+        id: list-x64
+        shell: pwsh
+        run: |
+          $whl = Get-ChildItem dist/qai_appbuilder-*.whl | Select-Object -First 1
+          if (-not $whl) { Write-Error "No wheel produced in dist/"; exit 1 }
+          Write-Host "Built: $($whl.Name)"
+          python -c "import sys, zipfile; [print(n) for n in zipfile.ZipFile(sys.argv[1]).namelist()]" $whl.FullName
+          # Expose the wheel basename (no .whl suffix) so upload-artifact can
+          # mirror the canonical wheel filename: e.g.
+          #   qai_appbuilder-2.47.0-cp312-cp312-win_amd64
+          $stem = [System.IO.Path]::GetFileNameWithoutExtension($whl.Name)
+          "wheel-stem=$stem" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.list-x64.outputs.wheel-stem }}-qnn${{ matrix.qnn.version }}
+          path: |
+            dist/*.whl
+            dist/*.zip
+          if-no-files-found: error
+
+      - name: Upload CMake logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs-win_amd64-py${{ matrix.python }}-qnn${{ matrix.qnn.version }}
+          path: |
+            build/**/CMakeFiles/CMakeOutput.log
+            build/**/CMakeFiles/CMakeError.log
+            build/**/CMakeCache.txt
+          if-no-files-found: ignore
+
+  build-windows-arm64:
+    name: arm64 wheel + test · py${{ matrix.python }} · qnn${{ matrix.qnn.version }}
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12', '3.13']
+        qnn:
+          # See windows-x64 matrix above for the genie-url convention.
+          - version: '2.47.0.260601'
+            url: ''
+            genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
+          - version: '2.46.0.260424'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.46.0.260424/v2.46.0.260424.zip'
+            genie-url: ''
+    steps:
+      - name: Checkout (with pybind11 submodule only)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init pybind11 submodule
+        shell: pwsh
+        run: |
+          git submodule update --init --depth 1 pybind/pybind11
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: 'arm64'
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: ${{ matrix.qnn.version }}
+          url: ${{ matrix.qnn.url }}
+          genie-runtime-url: ${{ matrix.qnn.genie-url }}
+          genie-runtime-version: ${{ matrix.qnn.version }}_v73
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel==0.45.1 setuptools==80.9.0 pybind11==2.13.6 build==1.4.0 "cmake>=3.21" pytest
+
+      - name: Build wheel
+        shell: pwsh
+        env:
+          QAI_TOOLCHAINS: aarch64-windows-msvc
+          QAI_HEXAGONARCH: '81'
+        run: |
+          python -m build -w --no-isolation
+
+      - name: List wheel contents
+        id: list-arm64
+        shell: pwsh
+        run: |
+          $whl = Get-ChildItem dist/qai_appbuilder-*.whl | Select-Object -First 1
+          if (-not $whl) { Write-Error "No wheel produced in dist/"; exit 1 }
+          Write-Host "Built: $($whl.Name)"
+          python -c "import sys, zipfile; [print(n) for n in zipfile.ZipFile(sys.argv[1]).namelist()]" $whl.FullName
+          $stem = [System.IO.Path]::GetFileNameWithoutExtension($whl.Name)
+          "wheel-stem=$stem" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.list-arm64.outputs.wheel-stem }}-qnn${{ matrix.qnn.version }}
+          path: |
+            dist/*.whl
+            dist/*.zip
+          if-no-files-found: error
+
+      - name: Install built wheel
+        shell: pwsh
+        run: |
+          $whl = (Get-ChildItem dist/qai_appbuilder-*.whl | Select-Object -First 1).FullName
+          pip install --force-reinstall $whl
+
+      - name: Install runtime deps for smoke test
+        shell: pwsh
+        # qai_appbuilder/__init__.py imports onnxwrapper, whose top-level
+        # imports include numpy and yaml. These are real runtime deps but
+        # are not declared in setup.py's install_requires (yet) — install
+        # them explicitly here so the wheel can be imported.
+        run: |
+          pip install numpy pyyaml
+
+      - name: Smoke test
+        shell: pwsh
+        # Two test files run here:
+        #  - test_package_smoke.py  : pure-Python imports + constants
+        #  - test_cpu_runtime_smoke.py : exercises the pybind C++ extension
+        #    and QNN CPU backend DLL discovery (no NPU, no .bin model).
+        # Together they catch ABI mismatches, missing bundled QNN DLLs,
+        # and pybind layer regressions before Stage B real-NPU testing.
+        run: |
+          pytest tests/test_package_smoke.py tests/test_cpu_runtime_smoke.py -v
+
+      - name: Upload CMake logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs-win_arm64-py${{ matrix.python }}-qnn${{ matrix.qnn.version }}
+          path: |
+            build/**/CMakeFiles/CMakeOutput.log
+            build/**/CMakeFiles/CMakeError.log
+            build/**/CMakeCache.txt
+          if-no-files-found: ignore
+
+  # -----------------------------------------------------------------
+  # Linux aarch64 — single combination (py3.12 x QNN 2.47).
+  # Uses ubuntu-22.04-arm hosted runner (native ARM64).
+  # Toolchain `aarch64-oe-linux-gcc11.2` and Hexagon arch 68 follow
+  # BUILD.md's Linux example. If the Community SDK zip turns out to
+  # not include the OE Linux libs, this job will surface that as a
+  # missing-file error in the build step.
+  # -----------------------------------------------------------------
+  build-linux-arm64:
+    name: linux arm64 wheel + test · py3.12 · qnn2.47.0.260601
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 45
+    steps:
+      - name: Checkout (with pybind11 submodule only)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init pybind11 submodule
+        run: git submodule update --init --depth 1 pybind/pybind11
+
+      - name: Install build toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build unzip
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: '2.47.0.260601'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel==0.45.1 setuptools==80.9.0 pybind11==2.13.6 build==1.4.0 "cmake>=3.21" pytest
+
+      - name: Build wheel
+        env:
+          QAI_TOOLCHAINS: aarch64-oe-linux-gcc11.2
+          QAI_HEXAGONARCH: '68'
+        run: |
+          python -m build -w --no-isolation
+
+      - name: List wheel contents
+        id: list-linux
+        run: |
+          whl=$(ls dist/qai_appbuilder-*.whl | head -n1)
+          if [ -z "$whl" ]; then echo "No wheel produced in dist/"; exit 1; fi
+          echo "Built: $(basename "$whl")"
+          python -c "import sys, zipfile; print('\n'.join(zipfile.ZipFile(sys.argv[1]).namelist()))" "$whl"
+          stem=$(basename "$whl" .whl)
+          echo "wheel-stem=${stem}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.list-linux.outputs.wheel-stem }}-qnn2.47.0.260601
+          path: |
+            dist/*.whl
+            dist/*.zip
+          if-no-files-found: error
+
+      - name: Install built wheel
+        run: |
+          whl=$(ls dist/qai_appbuilder-*.whl | head -n1)
+          pip install --force-reinstall "$whl"
+
+      - name: Install runtime deps for smoke test
+        # See windows-arm64 job for rationale.
+        run: pip install numpy pyyaml
+
+      - name: Smoke test
+        run: pytest tests/test_package_smoke.py tests/test_cpu_runtime_smoke.py -v
+
+      - name: Upload CMake logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs-linux_aarch64-py3.12-qnn2.47.0.260601
+          path: |
+            build/**/CMakeFiles/CMakeOutput.log
+            build/**/CMakeFiles/CMakeError.log
+            build/**/CMakeCache.txt
+          if-no-files-found: ignore
+
+  # -----------------------------------------------------------------
+  # Android — produces libappbuilder.so for arm64-v8a via NDK r26d.
+  # Output is a native shared library (NOT a wheel) used by Android
+  # apps that link against AppBuilder.
+  #
+  # Build is driven by make/Android.mk + make/Application.mk through
+  # ndk-build, mirroring BUILD.md's Android section. Tests are not
+  # run — exercising the .so requires an Android device.
+  # -----------------------------------------------------------------
+  build-android-arm64v8a:
+    name: android arm64-v8a libappbuilder.so · qnn2.47.0.260601
+    # Temporarily disabled. Upstream make/Android.mk now contains a
+    # QAIAppSvc executable target that pulls in src/SVC/main.cpp, but
+    # that file is Windows-only (uses #pragma once at top of a .cpp,
+    # plus <tchar.h> and other Windows headers). NDK build fails:
+    #
+    #   main.cpp:9:9: error: #pragma once in main file
+    #   Utils.hpp:15:10: fatal error: 'tchar.h' file not found
+    #
+    # The pre-existing libappbuilder shared-library target itself still
+    # compiles fine; only the new QAIAppSvc target is broken. Waiting
+    # for upstream to either gate the QAIAppSvc target on Windows or
+    # make src/SVC/main.cpp cross-platform. To re-enable, change the
+    # `if:` below back to a normal trigger guard.
+    if: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends unzip curl
+
+      - name: Setup Android NDK r26d
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26d
+          add-to-path: false
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: '2.47.0.260601'
+
+      - name: Build libappbuilder.so via ndk-build
+        env:
+          ANDROID_NDK_ROOT: ${{ steps.ndk.outputs.ndk-path }}
+        run: |
+          # Mirrors the command in the project Makefile's `android` target,
+          # but invokes the Linux ndk-build binary directly so we don't have
+          # to depend on Windows-only ndk-build.cmd.
+          #
+          # make/Android.mk concatenates QNN_SDK_ROOT with "include/QNN"
+          # WITHOUT a path separator (line 14), so the BUILD.md convention
+          # requires QNN_SDK_ROOT to end with a trailing slash. The
+          # setup-qnn-sdk action exports it without one (Path() based code
+          # in setup.py doesn't care), so add it back here for Android.
+          export QNN_SDK_ROOT="${QNN_SDK_ROOT%/}/"
+          echo "QNN_SDK_ROOT=$QNN_SDK_ROOT"
+          test -f "${QNN_SDK_ROOT}include/QNN/QnnInterface.h" \
+            || { echo "QnnInterface.h not found under ${QNN_SDK_ROOT}include/QNN"; ls "${QNN_SDK_ROOT}include" || true; exit 1; }
+
+          "$ANDROID_NDK_ROOT/ndk-build" \
+            APP_ALLOW_MISSING_DEPS=true \
+            APP_ABI=arm64-v8a \
+            NDK_PROJECT_PATH=./ \
+            NDK_APPLICATION_MK=make/Application.mk \
+            APP_BUILD_SCRIPT=make/Android.mk
+
+      - name: Verify output
+        run: |
+          out="libs/arm64-v8a/libappbuilder.so"
+          if [ ! -f "$out" ]; then
+            echo "Expected $out was not produced. Tree under libs/:"
+            find libs -maxdepth 3 -type f 2>/dev/null || true
+            exit 1
+          fi
+          ls -lh "$out"
+          file "$out"
+
+      - name: Upload libappbuilder.so artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libappbuilder-android-arm64v8a-qnn2.47.0.260601
+          path: libs/arm64-v8a/libappbuilder.so
+          if-no-files-found: error
+
+  # -----------------------------------------------------------------
+  # samples/genie/c++/Service — GenieAPIService Windows ARM64 build.
+  #
+  # Follows samples/genie/c++/docs/BUILD.md. This is a separate cmake
+  # project from the wheel above: cross-compiled from windows-2022 to
+  # ARM64, with all 11 genie/c++ submodules (llama.cpp, MNN, curl,
+  # cli11, libsamplerate, dr_libs, LibrosaCpp, cpp-httplib, json, stb,
+  # CLI11) initialized. Output: Service/GenieService_v<version>/ with
+  # GenieAPIService.exe and friends.
+  #
+  # Build-only — there's no smoke test that can run on a hosted ARM
+  # runner (Service needs an LLM model + NPU on a real X Elite to
+  # actually do anything). Real validation lives in Stage B.
+  # -----------------------------------------------------------------
+  build-genie-service-windows-arm64:
+    name: genie c++ Service · windows arm64 · qnn${{ matrix.qnn.version }}
+    runs-on: windows-2022
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # Build the Windows GenieAPIService against every Community SDK
+        # release we currently support. All `url` values point at the
+        # apigwx-aws.qualcomm.com mirror — keeping them explicit (instead
+        # of relying on the default softwarecenter URL) makes it trivial
+        # to add / drop versions: one line each.
+        #
+        # `genie-url` is the optional customized-Genie overlay zip
+        # published in qualcomm/qai-appbuilder releases. Today only v2.47
+        # has a published overlay; the other rows ship with the SDK-
+        # bundled (upstream) Genie. Fill in the URL for any row once an
+        # overlay zip is published for that version.
+        qnn:
+          - version: '2.40.1.251119'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.40.1.251119/v2.40.1.251119.zip'
+            genie-url: ''
+          - version: '2.41.0.251128'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.41.0.251128/v2.41.0.251128.zip'
+            genie-url: ''
+          - version: '2.42.0.251225'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.42.0.251225/v2.42.0.251225.zip'
+            genie-url: ''
+          - version: '2.43.0.260128'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.43.0.260128/v2.43.0.260128.zip'
+            genie-url: ''
+          - version: '2.44.0.260225'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.44.0.260225/v2.44.0.260225.zip'
+            genie-url: ''
+          - version: '2.45.0.260326'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.45.0.260326/v2.45.0.260326.zip'
+            genie-url: ''
+          - version: '2.46.0.260424'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.46.0.260424/v2.46.0.260424.zip'
+            genie-url: ''
+          - version: '2.47.0.260601'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.47.0.260601/v2.47.0.260601.zip'
+            genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
+    steps:
+      - name: Checkout (with genie submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init genie c++ + pybind11 submodules
+        shell: pwsh
+        # Only the genie/c++/External/* submodules + pybind11 are needed.
+        # pybind11 is here defensively in case any included CMake bit
+        # references it.
+        run: |
+          git submodule update --init --depth 1 pybind/pybind11
+          git submodule update --init --depth 1 --recursive samples/genie/c++/External
+
+      - name: Setup MSVC (amd64_arm64)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: ${{ matrix.qnn.version }}
+          url: ${{ matrix.qnn.url }}
+          genie-runtime-url: ${{ matrix.qnn.genie-url }}
+          genie-runtime-version: ${{ matrix.qnn.version }}_v73
+
+      - name: Append trailing slash to QNN_SDK_ROOT
+        shell: pwsh
+        # Service/src/GenieAPIService/dependents.cmake builds QNN paths by
+        # string-concatenating $ENV{QNN_SDK_ROOT} + "lib\\<abi>" with no
+        # separator (lines 17-18), so it requires QNN_SDK_ROOT to end with
+        # a path separator. setup-qnn-sdk action exports it without one
+        # (the wheel build's pathlib-based code does not care). Add it
+        # back for this job — same pattern as the Android job, just in
+        # PowerShell.
+        run: |
+          $root = $env:QNN_SDK_ROOT.TrimEnd('\','/') + '\'
+          "QNN_SDK_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "QNN_SDK_ROOT=$root"
+          if (-not (Test-Path "${root}lib\aarch64-windows-msvc\Genie.lib")) {
+            Write-Error "Expected Genie.lib not found at ${root}lib\aarch64-windows-msvc\Genie.lib"
+            Get-ChildItem "${root}lib\aarch64-windows-msvc" 2>$null | Select-Object Name
+            exit 1
+          }
+
+      - name: Install build helpers
+        shell: pwsh
+        # Ninja: not strictly required for the VS generator path BUILD.md
+        # uses (it relies on MSBuild via `cmake --build . --config Release`),
+        # but the doc lists it as a prereq so keep it installable for any
+        # subproject that switches generators.
+        run: |
+          choco install -y ninja --no-progress
+
+      - name: Configure GenieAPIService
+        shell: cmd
+        working-directory: samples/genie/c++/Service
+        # Per BUILD.md:
+        #   cmake -S .. -B . -A ARM64 ..
+        # That command has both -S/-B and a positional source-dir which
+        # newer cmake versions reject. Use the modern equivalent.
+        #
+        # USE_MNN and USE_GGUF are NOT enabled here. Both bring in large
+        # third-party builds (MNN, llama.cpp) that hit toolchain / host
+        # arch issues on hosted windows-2022 runners. Service is built
+        # with the BIN backend only. To re-enable later, add:
+        #   -DUSE_MNN=ON -DUSE_GGUF=ON
+        # and revisit the LLVM/clang-cl setup that previously worked
+        # locally but stalled in CI.
+        run: |
+          if not exist build mkdir build
+          cmake -S . -B build -A ARM64
+
+      - name: Build GenieAPIService
+        shell: cmd
+        working-directory: samples/genie/c++/Service
+        run: |
+          cmake --build build --config Release --parallel 4
+
+      - name: Verify output
+        shell: pwsh
+        working-directory: samples/genie/c++/Service
+        run: |
+          $out = Get-ChildItem -Directory -Filter "GenieService_v*" | Select-Object -First 1
+          if (-not $out) {
+            Write-Error "Expected GenieService_v*/ directory was not produced. Tree under Service/:"
+            Get-ChildItem -Recurse -Depth 2 | Select-Object FullName
+            exit 1
+          }
+          Write-Host "Output dir: $($out.FullName)"
+          Get-ChildItem $out.FullName -Recurse -File | Select-Object FullName, Length
+
+      - name: Upload GenieService artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: GenieService-windows-arm64-qnn${{ matrix.qnn.version }}
+          path: samples/genie/c++/Service/GenieService_v*/**
+          if-no-files-found: error
+
+      - name: Upload CMake logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs-genie-service-windows-arm64-qnn${{ matrix.qnn.version }}
+          path: |
+            samples/genie/c++/Service/build/**/CMakeFiles/CMakeOutput.log
+            samples/genie/c++/Service/build/**/CMakeFiles/CMakeError.log
+            samples/genie/c++/Service/build/**/CMakeCache.txt
+          if-no-files-found: ignore
+
+  # -----------------------------------------------------------------
+  # Release — only runs when a `v*` tag is pushed. Collects every
+  # artifact from the build jobs above and attaches them to a new
+  # GitHub Release at that tag.
+  #
+  # Trigger: push of a tag matching v*  (e.g. `git tag v2.47.0 && git push --tags`)
+  # Skip:    every regular branch push and pull_request — the `if:` below
+  #          gates the whole job.
+  # -----------------------------------------------------------------
+  # -----------------------------------------------------------------
+  # samples/genie/c++/Service — GenieAPIService Linux ARM64 build via
+  # the project-provided build_linux.sh.
+  #
+  # Runs on ubuntu-22.04-arm (native aarch64). The script does the
+  # configure + build of Service/, also builds libsamplerate from the
+  # bundled External/ submodule, and copies QAIRT runtime libs +
+  # default model config files into Service/GenieService_v<APPVER>_qnn<SDKVER>/.
+  #
+  # Build-only — running GenieAPIService needs an LLM model and an
+  # NPU/HTP backend, which is Stage B real-hardware territory.
+  # -----------------------------------------------------------------
+  build-genie-service-linux-arm64:
+    name: genie c++ Service · linux arm64 · qnn2.47.0.260601
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 60
+    steps:
+      - name: Checkout (with genie submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init genie c++ + pybind11 submodules
+        # The Service build runs ExternalProject for libappbuilder out of
+        # the repo root, which references pybind11. The genie/c++/External
+        # submodules cover libsamplerate, CLI11, json, cpp-httplib, dr_libs,
+        # stb, LibrosaCpp — all required by build_linux.sh's submodule check.
+        run: |
+          git submodule update --init --depth 1 pybind/pybind11
+          git submodule update --init --depth 1 --recursive samples/genie/c++/External
+
+      - name: Install build toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build unzip
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: '2.47.0.260601'
+
+      - name: Append trailing slash to QNN_SDK_ROOT
+        # build_linux.sh's downstream cmake (in dependents.cmake) does
+        # string concat with QNN_SDK_ROOT — same trailing-slash convention
+        # as the Windows Service / Android jobs.
+        run: |
+          root="${QNN_SDK_ROOT%/}/"
+          echo "QNN_SDK_ROOT=$root" >> "$GITHUB_ENV"
+          echo "QNN_SDK_ROOT=$root"
+          test -d "${root}lib/aarch64-oe-linux-gcc11.2" \
+            || { echo "Expected aarch64-oe-linux-gcc11.2 lib dir missing under $root"; ls "${root}lib" || true; exit 1; }
+
+      - name: Build GenieAPIService via build_linux.sh
+        # Run the project-provided helper script verbatim — the same path
+        # local devs follow per BUILD_LINUX.md. USE_MNN/USE_GGUF stay OFF
+        # for the same toolchain reasons we hit on Windows.
+        run: |
+          chmod +x samples/genie/c++/build_linux.sh
+          (cd samples/genie/c++ && ./build_linux.sh)
+
+      - name: Locate output and verify
+        id: locate
+        run: |
+          out_dir=$(find samples/genie/c++/Service -maxdepth 1 -type d -name 'GenieService_v*_qnn*' | head -n1)
+          if [ -z "$out_dir" ]; then
+            echo "Expected GenieService_v*_qnn*/ output directory not found:"
+            ls -la samples/genie/c++/Service/ || true
+            exit 1
+          fi
+          echo "Output dir: $out_dir"
+          ls -lh "$out_dir"
+          echo "out-name=$(basename "$out_dir")" >> "$GITHUB_OUTPUT"
+          echo "out-dir=$out_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Upload GenieService artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.locate.outputs.out-name }}-linux_aarch64
+          path: ${{ steps.locate.outputs.out-dir }}/**
+          if-no-files-found: error
+
+      - name: Upload CMake logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmake-logs-genie-service-linux-arm64
+          path: |
+            samples/genie/c++/Service/build/**/CMakeFiles/CMakeOutput.log
+            samples/genie/c++/Service/build/**/CMakeFiles/CMakeError.log
+            samples/genie/c++/Service/build/**/CMakeCache.txt
+          if-no-files-found: ignore
+
+  # -----------------------------------------------------------------
+  # samples/genie/c++/Service — Android arm64-v8a build via the
+  # project-provided build_android.bat.
+  #
+  # Runs on windows-2022 (the .bat is Windows-only). The script builds
+  # libappbuilder.so, libGenieAPIService.so, libJNIGenieAPIService.so,
+  # then attempts to assemble a release APK via Gradle. The APK step
+  # requires a release-signing keystore (configured in
+  # Android/app/build.gradle.kts) which doesn't exist on the runner —
+  # the script's :skip_apk fallback gracefully exits with the .so files
+  # already produced. continue-on-error keeps the run "green-with-
+  # unsigned-libs" until proper signing secrets are wired up.
+  # -----------------------------------------------------------------
+  build-android-genie-service:
+    name: genie c++ Service · android arm64-v8a · qnn2.47.0.260601
+    runs-on: windows-2022
+    timeout-minutes: 60
+    # APK-signing step is expected to fail on hosted runners until a
+    # release keystore is wired up via secrets. .so artifacts produced
+    # before that step are still uploaded.
+    continue-on-error: true
+    steps:
+      - name: Checkout (with genie submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init genie c++ + pybind11 submodules
+        shell: pwsh
+        run: |
+          git submodule update --init --depth 1 pybind/pybind11
+          git submodule update --init --depth 1 --recursive samples/genie/c++/External
+
+      - name: Setup Android NDK r26d
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26d
+          add-to-path: false
+
+      - name: Setup QNN SDK
+        uses: ./.github/actions/setup-qnn-sdk
+        with:
+          version: '2.47.0.260601'
+
+      - name: Install ninja
+        shell: pwsh
+        run: choco install -y ninja --no-progress
+
+      - name: Patch build_android.bat for CI paths
+        shell: pwsh
+        # The script hard-codes:
+        #   set "QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.46.0.260424\"
+        #   set "NDK_ROOT=C:\work\android-ndk-r26d-windows\android-ndk-r26d\"
+        # Rewrite both lines in-place so the script picks up the runner-
+        # provisioned QNN SDK + NDK. Trailing slash kept (the script's
+        # downstream make/cmake assumes it).
+        #
+        # NDK path uses FORWARD slashes — the project Makefile (line 24)
+        # passes ANDROID_NDK_ROOT directly to a shell command that's
+        # parsed by GNU make's bash, which eats backslashes as escape
+        # characters. Forward slashes work everywhere on Windows for
+        # this NDK shipped with cmd.exe + bash.
+        run: |
+          $bat = 'samples/genie/c++/build_android.bat'
+          $qnn = ($env:QNN_SDK_ROOT.TrimEnd('\','/') + '\').Replace('/', '\')
+          $ndk = ('${{ steps.ndk.outputs.ndk-path }}'.TrimEnd('\','/') + '/').Replace('\', '/')
+          (Get-Content $bat) `
+            -replace 'set "QNN_SDK_ROOT=.*?"', ('set "QNN_SDK_ROOT=' + $qnn + '"') `
+            -replace 'set "NDK_ROOT=.*?"',     ('set "NDK_ROOT='     + $ndk + '"') `
+            | Set-Content $bat
+          Write-Host "Patched paths:"
+          Select-String -Path $bat -Pattern 'set "QNN_SDK_ROOT=|set "NDK_ROOT=' | Select-Object -ExpandProperty Line
+
+      - name: Build via build_android.bat
+        shell: cmd
+        working-directory: samples/genie/c++
+        run: |
+          call build_android.bat
+
+      - name: Verify .so output
+        shell: pwsh
+        # The .so files land here regardless of whether the later APK
+        # signing step succeeds, so verify them independently.
+        run: |
+          $out = 'samples/genie/c++/build_android/output/libs/arm64-v8a'
+          if (-not (Test-Path $out)) {
+            Write-Error "Expected output dir $out not found."
+            Get-ChildItem 'samples/genie/c++/build_android' -Recurse -Depth 3 -ErrorAction SilentlyContinue | Select-Object FullName
+            exit 1
+          }
+          Get-ChildItem $out | Select-Object Name, Length
+          $required = @('libappbuilder.so', 'libGenieAPIService.so')
+          foreach ($f in $required) {
+            if (-not (Test-Path (Join-Path $out $f))) {
+              Write-Error "Required artifact missing: $f"
+              exit 1
+            }
+          }
+
+      - name: Upload Android .so artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: GenieService-android-arm64v8a-libs-qnn2.47.0.260601
+          path: samples/genie/c++/build_android/output/libs/arm64-v8a/*.so
+          if-no-files-found: error
+
+      - name: Upload Android APK if produced
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: GenieService-android-arm64v8a-apk-qnn2.47.0.260601
+          path: samples/genie/c++/build_android/output/apk/*.apk
+          if-no-files-found: ignore
+
+  release:
+    name: Publish GitHub Release
+    # Temporarily disabled — re-enable once all build jobs (especially
+    # Genie Service with USE_GGUF) are stable. To re-enable, change the
+    # condition back to:
+    #   if: startsWith(github.ref, 'refs/tags/v')
+    if: false
+    needs:
+      - build-windows-x64
+      - build-windows-arm64
+      - build-linux-arm64
+      # - build-android-arm64v8a   # disabled until upstream fixes SVC main.cpp on Android
+      - build-genie-service-windows-arm64
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required for action-gh-release to create the Release
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts for release
+        shell: bash
+        # actions/download-artifact@v4 lands each artifact in its own
+        # subdir. action-gh-release wants a flat file list; copy the
+        # *.whl / *.zip / *.so / GenieService dirs into a single dir.
+        run: |
+          mkdir -p release
+          # wheels and release zips from wheel jobs
+          find artifacts -type f \( -name '*.whl' -o -name 'QAI_AppBuilder-*.zip' \) -exec cp -v {} release/ \;
+          # android .so — rename to include the artifact label so it doesn't collide
+          if [ -f artifacts/libappbuilder-android-arm64v8a-qnn2.47.0.260601/libappbuilder.so ]; then
+            cp -v artifacts/libappbuilder-android-arm64v8a-qnn2.47.0.260601/libappbuilder.so \
+                  release/libappbuilder-android-arm64v8a-qnn2.47.0.260601.so
+          fi
+          # Genie c++ Service: zip the whole tree
+          genie_dir=$(find artifacts -type d -name 'GenieService-windows-arm64-*' | head -n1)
+          if [ -n "$genie_dir" ]; then
+            (cd "$genie_dir" && zip -qr "${GITHUB_WORKSPACE}/release/GenieService-windows-arm64-qnn2.47.0.260601.zip" .)
+          fi
+          echo "Release payload:"
+          ls -lh release/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-dist/	dist/
+dist/
+build/
+lib/
+*.egg-info/
+*.whl
+__pycache__/
+*.pyc

--- a/samples/genie/c++/Service/src/GenieAPIService/src/model/def.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/model/def.h
@@ -91,7 +91,7 @@ struct ModelType : public BaseEnum
 namespace std
 {
     template<>
-    struct std::hash<ModelType>
+    struct hash<ModelType>
     {
         size_t operator()(ModelType const &m) const noexcept { return std::hash<int>{}(int(m)); }
     };

--- a/samples/python/utils/image_processing.py
+++ b/samples/python/utils/image_processing.py
@@ -8,6 +8,7 @@ import math
 import torchvision.transforms as transforms
 from PIL.Image import Image
 from PIL.Image import fromarray as ImageFromArray
+from qai_hub_models.utils.image_processing import numpy_image_to_torch
 from torch.nn.functional import interpolate, pad
 import torch
 from typing import Tuple, Dict

--- a/script/qai_appbuilder/onnxwrapper.py
+++ b/script/qai_appbuilder/onnxwrapper.py
@@ -658,10 +658,12 @@ class QNNModelWrapper(QNNContext):
         exp_shapes = self._expected_input_shapes
         exp_rank: Dict[str, Optional[int]] = {n: None for n in full_in_names}
         exp_layout: Dict[str, Optional[str]] = {n: None for n in full_in_names}
+        exp_shape_by_name: Dict[str, Optional[Any]] = {n: None for n in full_in_names}
         if exp_shapes:
             for n, s in zip(full_in_names, exp_shapes):
                 exp_rank[n] = len(s) if isinstance(s, (list, tuple)) else None
                 exp_layout[n] = _infer_layout_from_shape(s)
+                exp_shape_by_name[n] = s
 
         processed: List[np.ndarray] = []
         for n, t in zip(used_names, input_tensors):
@@ -817,6 +819,7 @@ class InferenceSession:
             log_level = log_level_map.get(sess_options.log_severity_level, LogLevel.ERROR)
             _ensure_path_contains(sess_options.qnn_libs_dir)
             QNNConfig.Config(
+                sess_options.qnn_libs_dir,
                 sess_options.qnn_runtime,
                 log_level,
                 sess_options.qnn_profiling_level,

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,15 @@ def _is_wos_device() -> bool:
     and PROCESSOR_IDENTIFIER / PROCESSOR_ARCHITECTURE environment variables.
     Returns True if running on a WOS (ARM64) device, False on a real x86_64 PC.
     """
+    # Explicit user request via QAI_TOOLCHAINS overrides host detection.
+    # This is the path CI uses: cross-build ARM64EC / ARM64 wheels from an
+    # x86_64 hosted runner. Without this hook, _detect_arch() would pick
+    # "x86_64" on the x64 build machine and request a non-existent
+    # x86_64-windows-msvc SDK toolchain.
+    qai_toolchains = os.environ.get("QAI_TOOLCHAINS", "").lower()
+    if qai_toolchains in ("arm64x-windows-msvc", "aarch64-windows-msvc"):
+        return True
+
     # Check PROCESSOR_ARCHITECTURE env var (set by Windows)
     proc_arch = os.environ.get("PROCESSOR_ARCHITECTURE", "").upper()
     proc_id = os.environ.get("PROCESSOR_IDENTIFIER", "").upper()

--- a/setup.py
+++ b/setup.py
@@ -856,6 +856,13 @@ setup(
     author_email="quic_zhanweiw@quicinc.com",
     license="BSD-3-Clause",
     python_requires=">=3.10",
+    install_requires=[
+        # qai_appbuilder/__init__.py unconditionally imports onnxwrapper,
+        # whose top-level imports require numpy + pyyaml. Without these,
+        # `pip install qai-appbuilder` in a clean venv fails to import.
+        "numpy",
+        "pyyaml",
+    ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3.12",

--- a/tests/test_cpu_runtime_smoke.py
+++ b/tests/test_cpu_runtime_smoke.py
@@ -49,10 +49,11 @@ def test_set_log_level_calls_through_pybind() -> None:
 def test_qnn_cpu_backend_dll_is_bundled_and_loadable() -> None:
     """Configuring with Runtime.CPU must succeed on any platform.
 
-    QNNConfig.Config() with no qnn_lib_path falls back to the wheel-bundled
-    qai_appbuilder/libs/ directory (qnncontext.py:137-138). It then asserts
-    QnnCpu.dll and QnnSystem.dll exist (lines 149-152), and finally invokes
-    the pybind set_log_level + set_profiling_level functions (lines 154-155).
+    QNNConfig.Config() resolves the wheel-bundled qai_appbuilder/libs/ dir
+    (the qnn_lib_path argument was removed upstream — the wheel-bundled
+    libs/ is the only supported location). It then asserts QnnCpu.dll
+    and QnnSystem.dll exist, and finally invokes the pybind
+    set_log_level + set_profiling_level functions.
 
     A pass therefore proves four things at once:
     1. the wheel packaged QnnCpu.dll
@@ -63,7 +64,6 @@ def test_qnn_cpu_backend_dll_is_bundled_and_loadable() -> None:
     from qai_appbuilder import LogLevel, ProfilingLevel, QNNConfig, Runtime
 
     QNNConfig.Config(
-        qnn_lib_path="None",
         runtime=Runtime.CPU,
         log_level=LogLevel.ERROR,
         profiling_level=ProfilingLevel.OFF,

--- a/tests/test_cpu_runtime_smoke.py
+++ b/tests/test_cpu_runtime_smoke.py
@@ -1,0 +1,70 @@
+"""Deeper CPU-only smoke tests for the qai_appbuilder wheel.
+
+Goes beyond `test_package_smoke.py` (which only checks Python-level imports
+and constants) by exercising the pybind11 native extension and the QNN
+backend DLL discovery path. None of these tests require a Snapdragon NPU
+or a precompiled .bin model — they run on any ARM64 Windows host that
+has the wheel installed, including GitHub-hosted windows-11-arm runners.
+
+What is covered:
+- pybind C++ extension loads and exposes set_log_level / set_profiling_level
+- QNNConfig.Config(runtime=CPU) finds bundled QnnCpu.dll + QnnSystem.dll
+- That same call routes through the pybind layer into native code
+  (set_log_level + set_profiling_level are invoked at the end of Config())
+
+What is NOT covered (and cannot be on a non-NPU runner):
+- Loading a .bin context binary (HTP-compiled, fails on CPU runtime)
+- Any actual inference
+- HTP-only paths: PerfProfile, device infrastructure
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_pybind_extension_exposes_native_symbols() -> None:
+    """The compiled qai_appbuilder.appbuilder pybind module must load and
+    expose the global-state functions that don't need a model.
+    """
+    appbuilder = importlib.import_module("qai_appbuilder.appbuilder")
+
+    for symbol in ("set_log_level", "set_profiling_level"):
+        assert hasattr(appbuilder, symbol), f"pybind module is missing {symbol}"
+        assert callable(getattr(appbuilder, symbol)), f"{symbol} is not callable"
+
+
+def test_set_log_level_calls_through_pybind() -> None:
+    """Calling set_log_level should round-trip through C++ without raising.
+
+    This proves the native .pyd is loadable on this architecture and that
+    Python -> C++ argument marshalling for the simplest exposed function
+    is intact.
+    """
+    from qai_appbuilder import LogLevel
+
+    LogLevel.SetLogLevel(LogLevel.ERROR, "None")
+
+
+def test_qnn_cpu_backend_dll_is_bundled_and_loadable() -> None:
+    """Configuring with Runtime.CPU must succeed on any platform.
+
+    QNNConfig.Config() with no qnn_lib_path falls back to the wheel-bundled
+    qai_appbuilder/libs/ directory (qnncontext.py:137-138). It then asserts
+    QnnCpu.dll and QnnSystem.dll exist (lines 149-152), and finally invokes
+    the pybind set_log_level + set_profiling_level functions (lines 154-155).
+
+    A pass therefore proves four things at once:
+    1. the wheel packaged QnnCpu.dll
+    2. the wheel packaged QnnSystem.dll
+    3. the pybind extension is callable
+    4. the bundled libs/ path resolution logic is correct on this runner
+    """
+    from qai_appbuilder import LogLevel, ProfilingLevel, QNNConfig, Runtime
+
+    QNNConfig.Config(
+        qnn_lib_path="None",
+        runtime=Runtime.CPU,
+        log_level=LogLevel.ERROR,
+        profiling_level=ProfilingLevel.OFF,
+    )

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,0 +1,69 @@
+"""Smoke tests for the installed qai_appbuilder wheel.
+
+These tests intentionally avoid loading a real model so they can run in CI after
+building and installing the wheel. The wheel build itself validates that the
+native extension can be compiled and linked against the configured QAIRT/QNN SDK.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_package_imports() -> None:
+    """Verify the top-level package can be imported.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    module = importlib.import_module("qai_appbuilder")
+
+    assert hasattr(module, "__version__")
+
+
+def test_qnn_api_symbols_are_exported() -> None:
+    """Verify commonly used QNN Python API symbols are exported.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    module = importlib.import_module("qai_appbuilder")
+
+    expected_symbols = [
+        "QNNConfig",
+        "QNNContext",
+        "Runtime",
+        "LogLevel",
+        "ProfilingLevel",
+        "PerfProfile",
+        "DataType",
+    ]
+
+    for symbol in expected_symbols:
+        assert hasattr(module, symbol), f"Missing exported symbol: {symbol}"
+
+
+def test_qnn_constant_values() -> None:
+    """Verify stable public constant values used by samples and applications.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    module = importlib.import_module("qai_appbuilder")
+
+    assert module.Runtime.CPU == "Cpu"
+    assert module.Runtime.HTP == "Htp"
+    assert module.DataType.FLOAT == "float"
+    assert module.DataType.NATIVE == "native"
+    assert module.PerfProfile.DEFAULT == "default"
+    assert module.PerfProfile.HIGH_PERFORMANCE == "high_performance"
+    assert module.PerfProfile.BURST == "burst"


### PR DESCRIPTION
## Summary

End-to-end GitHub Actions CI pipeline that builds and tests
`qai_appbuilder` (wheels) and `GenieAPIService` (C++ binary) across all
currently supported platforms, plus four source-level bug fixes
uncovered while standing the pipeline up.

All jobs run on **GitHub-hosted runners** — no self-hosted infrastructure
required. QAIRT Community SDK is downloaded and cached automatically.

## What's included

### CI workflows
- `.github/workflows/ci.yml` — main pipeline
- `.github/actions/setup-qnn-sdk/action.yml` — reusable composite action
  that downloads + caches the QAIRT Community SDK and optionally overlays
  the customized Genie zip on Windows

### Build matrix

| target | runner | SDK versions | smoke test |
|---|---|---|---|
| `qai_appbuilder` wheel (win_amd64, ARM64EC) | windows-2022 | 2.46, 2.47 × py 3.11/3.12/3.13 | n/a (cross-compile) |
| `qai_appbuilder` wheel (win_arm64) | windows-11-arm | 2.46, 2.47 × py 3.11/3.12/3.13 | ✓ |
| `qai_appbuilder` wheel (linux_aarch64) | ubuntu-22.04-arm | 2.47, py 3.12 | ✓ |
| `GenieAPIService` (Windows ARM64) | windows-2022 | 2.41 → 2.47 (7 SDKs) | n/a |
| `GenieAPIService` (Linux ARM64) | ubuntu-22.04-arm | 2.47 | n/a |
| `GenieAPIService` (Android arm64-v8a) | windows-2022 | 2.47 | n/a (continue-on-error: APK signing keystore not configured) |

### Smoke tests (`tests/`)
- `test_package_smoke.py` — Python-level: imports, public API symbols,
  constant values
- `test_cpu_runtime_smoke.py` — pybind11 native extension + bundled
  QnnCpu.dll / QnnSystem.dll discovery (no NPU required)

### Source-level fixes

1. **`setup.py`** — declare `install_requires=["numpy", "pyyaml"]`.
   `qai_appbuilder/__init__.py` unconditionally imports `onnxwrapper`,
   which top-imports `numpy` and `yaml`. Without these declared,
   `pip install qai-appbuilder` followed by `import qai_appbuilder` in a
   clean venv fails with `ModuleNotFoundError`. Release-blocker for any
   downstream user.

2. **`setup.py` — `_is_wos_device()` honours `QAI_TOOLCHAINS`**. When CI
   sets `QAI_TOOLCHAINS=arm64x-windows-msvc` or `aarch64-windows-msvc`
   on a real x86_64 hosted runner, treat that as an explicit WOS
   override. Otherwise `_detect_arch()` returns `"x86_64"` and asks for
   the SDK's `x86_64-windows-msvc` toolchain subdir, which the
   Community SDK does not ship, breaking 26 GenieBuilder symbol links.

3. **`samples/python/utils/image_processing.py:205`** — add missing
   `from qai_hub_models.utils.image_processing import numpy_image_to_torch`.
   Same import pattern is already used in
   `samples/python/mediapipe_hand/mediapipe_hand.py`. Reaching the
   affected branch raised `NameError` before this fix; ruff F821
   flagged it.

4. **`script/qai_appbuilder/onnxwrapper.py:681`** — construct
   `exp_shape_by_name` dict alongside sibling `exp_rank` / `exp_layout`
   dicts. The lookup referenced the variable without it being defined;
   a bare `except Exception` silently masked the `NameError` into
   `None`, so the auto-scale heuristic that detects [0,1] → [0,255]
   image inputs never received the expected shape. Models that needed
   auto-scaling silently received wrong input ranges.

5. **`samples/genie/c++/Service/src/GenieAPIService/src/model/def.h:94`**
   — drop redundant `std::` qualifier on `std::hash<ModelType>`
   specialisation. MSVC accepted `struct std::hash<X>` inside
   `namespace std { ... }`, but gcc 11 (Linux Service build) rejects it
   with `extra qualification not allowed [-fpermissive]`. Standard form
   is `struct hash<X>`.

## Test plan

- [ ] `lint` job green
- [ ] 6 Windows x64 wheel builds green (3 Python × 2 QNN)
- [ ] 6 Windows ARM64 wheel builds + smoke tests green
- [ ] Linux aarch64 wheel + smoke test green
- [ ] All 7 Windows GenieAPIService matrix rows green (2.41 → 2.47)
- [ ] Linux Service build green
- [ ] Android Service `.so` artifacts produced (APK assembly may fail
      until signing secrets are wired up)

## Known limitations / out of scope

- **`samples/genie/c++/Service/src/GenieAPIService/dependents.cmake`
  not touched**. Upstream `8831505` already improved this file
  substantially (Linux/Android branches, CLI11 probe, out-of-source
  builds). The development branch had additional
  VS-edition-agnostic / host-arch-aware clang lookup logic, but those
  changes only matter when `USE_MNN=ON` or `USE_GGUF=ON`, which this PR
  keeps OFF. A follow-up PR can revisit if/when re-enabling those
  backends in CI.
- **Android `libappbuilder.so` job is currently `if: false`**. The
  upstream `make/Android.mk` now pulls `src/SVC/main.cpp` into a
  `QAIAppSvc` target, but that file is Windows-only (`<tchar.h>`,
  `#pragma once` at top of `.cpp`). Will re-enable once SVC main.cpp is
  made cross-platform.
- **`release` job is `if: false`**. Triggers on `v*` tag push but kept
  disabled until the full matrix is observed stable in production.
- **QNN SDK 2.40.1.251119 dropped from matrix** — its Community zip
  returns S3 NoSuchKey at apigwx-aws. The other seven SDKs in the
  matrix are unaffected.

## Development history

Squashed CI work plus 4 incremental fixes uncovered while running the
new pipeline. The full ~40-commit development branch lives at
`shijunz/ai-engine-direct-helper:ci-stage-a` and documents how each
fix was discovered.
