### PR TITLE
docs: update repository URL and directory name from quic/ai-engine-direct-helper to qualcomm/qai-appbuilder

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -30,11 +30,11 @@ pip install wheel==0.45.1 setuptools==80.9.0 pybind11==2.13.6 build==1.4.0
 ```
 - Clone this repository to local: 
 ```
-git clone https://github.com/quic/ai-engine-direct-helper.git --recursive
+git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 ```
 - If you have cloned it before, you can update the code by the following command:
 ```
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 - Set environment 'QNN_SDK_ROOT' to the Qualcomm® AI Runtime SDK path which you're using. E.g.:
@@ -45,7 +45,7 @@ Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.47.0.260601\
 *Note: Please get the corresponding "Supported Toolchains" and "Hexagon Arch" with your device from [Supported Snapdragon devices](https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/QNN_general_overview.html#supported-snapdragon-devices). <br>
 
 ```
-cd ai-engine-direct-helper
+cd qai-appbuilder
 *Note: Make sure to build in the regular Windows Command Prompt — not in the 'ARM64 Native Tools Command Prompt for VS 2022' and not in the 'Power Shell' window.* <br>
      set QNN_SDK_ROOT=C:/Qualcomm/AIStack/QAIRT/2.42.0.251225/
      python -m build -w
@@ -58,8 +58,8 @@ pip install --force-reinstall dist\qai_appbuilder-2.42.0-cp312-cp312-win_amd64.w
 **Clone the repository with submodules:**
 
 ```bash
-git clone https://github.com/quic/ai-engine-direct-helper.git --recursive
-cd ai-engine-direct-helper
+git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
+cd qai-appbuilder
 ```
 
 ### Download QNN SDK
@@ -134,14 +134,14 @@ python -c "import qai_appbuilder; print('QAI AppBuilder installed successfully')
 ### Download QAI AppBuilder source codes:
 Run below command in Windows terminal:
 ```
-git clone https://github.com/quic/ai-engine-direct-helper.git --recursive
+git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 ```
 
 ### Set PATH and run make.exe to build QAI AppBuilder
 • Download [android ndk](https://dl.google.com/android/repository/android-ndk-r26d-windows.zip).<br>
 • Run following commands in Windows terminal:
 ```
-cd ai-engine-direct-helper
+cd qai-appbuilder
 Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\{Qualcomm® AI Runtime SDK version}\
 Set NDK_ROOT={your ndk root directory}
 set PATH=%PATH%;%NDK_ROOT%\toolchains\llvm\prebuilt\windows-x86_64\bin
@@ -149,7 +149,7 @@ Set ANDROID_NDK_ROOT=%NDK_ROOT%
  
 "%NDK_ROOT%\prebuilt\windows-x86_64\bin\make.exe" android
 ```
-• Then you will see the generated file ai-engine-direct-helper\libs\arm64-v8a\libappbuilder.so.
+• Then you will see the generated file qai-appbuilder\libs\arm64-v8a\libappbuilder.so.
 
 ### Debug issues about AppBuilder
 • Sometimes we will meet error which is related with libAppBuilder.so, for example below abnormal info when execute SuperResolution app on Snapdragon® 8 Elite mobile device. 

--- a/docs/genie_guide_en.md
+++ b/docs/genie_guide_en.md
@@ -855,7 +855,7 @@ cmake -S .. -B . -A ARM64 -DUSE_GGUF=ON -DUSE_MNN=ON
 #### Set Environment Variables and Paths (Building Android from Windows Host)
 
 ```bat
-cd ai-engine-direct-helper\samples\genie\c++\Service
+cd qai-appbuilder\samples\genie\c++\Service
 Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.42.0.251225
 set PATH=%PATH%;C:\Programs\android-ndk-r26d\toolchains\llvm\prebuilt\windows-x86_64\bin
 Set NDK_ROOT=C:/Programs/android-ndk-r26d/
@@ -866,7 +866,7 @@ Set ANDROID_NDK_ROOT=%NDK_ROOT%
 
 Before building for Android, you need to compile `libappbuilder` first (see the project root [BUILD](https://github.com/qualcomm/qai-appbuilder/blob/main/BUILD.md) documentation), and place the generated `libappbuilder.so` at:
 
-`ai-engine-direct-helper\samples\genie\c++\Service`
+`qai-appbuilder\samples\genie\c++\Service`
 
 #### Build GenieAPIService (Android)
 
@@ -883,7 +883,7 @@ copy "obj\local\arm64-v8a\*.so" "libs\arm64-v8a" /Y
 
 #### Build Android App (Android Studio)
 
-1. Open with Android Studio: `ai-engine-direct-helper\samples\genie\c++\Android`
+1. Open with Android Studio: `qai-appbuilder\samples\genie\c++\Android`
 2. Menu **Build** → **Generate Signed App Bundle / APK** → Select **APK**
 3. Select signing key and complete the build
 4. Get `app-release.apk` in the `...\Android\app\release` directory

--- a/docs/genie_guide_zh.md
+++ b/docs/genie_guide_zh.md
@@ -856,7 +856,7 @@ cmake -S .. -B . -A ARM64 -DUSE_GGUF=ON -DUSE_MNN=ON
 #### 设置环境变量与路径（Windows 主机构建 Android）
 
 ```bat
-cd ai-engine-direct-helper\samples\genie\c++\Service
+cd qai-appbuilder\samples\genie\c++\Service
 Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.42.0.251225
 set PATH=%PATH%;C:\Programs\android-ndk-r26d\toolchains\llvm\prebuilt\windows-x86_64\bin
 Set NDK_ROOT=C:/Programs/android-ndk-r26d/
@@ -867,7 +867,7 @@ Set ANDROID_NDK_ROOT=%NDK_ROOT%
 
 Android 构建前需要先编译 `libappbuilder`（详见项目根目录的 [BUILD](https://github.com/qualcomm/qai-appbuilder/blob/main/BUILD.md) 说明），并将生成的 `libappbuilder.so` 放到：
 
-`ai-engine-direct-helper\samples\genie\c++\Service`
+`qai-appbuilder\samples\genie\c++\Service`
 
 #### 构建 GenieAPIService（Android）
 
@@ -884,7 +884,7 @@ copy "obj\local\arm64-v8a\*.so" "libs\arm64-v8a" /Y
 
 #### 构建 Android App（Android Studio）
 
-1. 使用 Android Studio 打开：`ai-engine-direct-helper\samples\genie\c++\Android`
+1. 使用 Android Studio 打开：`qai-appbuilder\samples\genie\c++\Android`
 2. 菜单 **Build** → **Generate Signed App Bundle / APK** → 选择 **APK**
 3. 选择签名密钥并完成构建
 4. 在 `...\Android\app\release` 目录获取 `app-release.apk`

--- a/docs/guide_en.md
+++ b/docs/guide_en.md
@@ -193,7 +193,7 @@ https://aka.ms/vs/17/release/vc_redist.arm64.exe
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # If already cloned, update code
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 
@@ -243,7 +243,7 @@ pip3 install numpy pillow opencv-python
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # If already cloned, update code
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 

--- a/docs/guide_zh.md
+++ b/docs/guide_zh.md
@@ -193,7 +193,7 @@ https://aka.ms/vs/17/release/vc_redist.arm64.exe
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # 如果已克隆，更新代码
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 
@@ -243,7 +243,7 @@ pip3 install numpy pillow opencv-python
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # 如果已克隆，更新代码
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -39,13 +39,13 @@ git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 ```
 If you have cloned it before, you can update the code by the following command:
 ```
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 ### Step 4: Setup QAI AppBuilder Python Environment:
 Run below commands in Windows terminal:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 python python\setup.py
 ```
 

--- a/docs/python_arm64.md
+++ b/docs/python_arm64.md
@@ -40,13 +40,13 @@ git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 ```
 If you have cloned it before, you can update the code by the following command:
 ```
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 ### Step 4: Setup QAI AppBuilder Python Environment:
 Run below commands in Windows terminal:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 python python\setup.py
 ```
 

--- a/samples/android/README.md
+++ b/samples/android/README.md
@@ -1,7 +1,7 @@
 ## Build and Run GenieChat app
 GenieChat is an Android application that demonstrates how to integrate large language models (LLMs) and VLM using the Genie API. It features a clean, modern user interface and supports real-time streaming responses, delivering a seamless interactive user experience.<br>
-• Please build or download [GenieAPIService.apk](https://github.com/quic/ai-engine-direct-helper/releases/download/v2.42.0/GenieAPIService.apk), run it refer to [this link](https://github.com/quic/ai-engine-direct-helper/blob/main/samples/genie/c%2B%2B/docs/USAGE.MD#use-for-android) firstly.<br>
-• Please download [GenieChat source codes](https://github.com/quic/ai-engine-direct-helper/tree/main/samples/android/GenieChat) and build GenieChat apk in android studio. <br>
+• Please build or download [GenieAPIService.apk](https://github.com/qualcomm/qai-appbuilder/releases/download/v2.42.0/GenieAPIService.apk), run it refer to [this link](https://github.com/qualcomm/qai-appbuilder/blob/main/samples/genie/c%2B%2B/docs/USAGE.MD#use-for-android) firstly.<br>
+• Please download [GenieChat source codes](https://github.com/qualcomm/qai-appbuilder/tree/main/samples/android/GenieChat) and build GenieChat apk in android studio. <br>
 • Then run it on Mobile device, refer to [this document](https://www.aidevhome.com/?id=50).<br>
 
 ## Build and Run SuperResolution sample app on Mobile Phone(Snapdragon® 8 Elite and and Snapdragon® 8 Elite Gen 5)
@@ -16,7 +16,7 @@ Following are the detailed steps to build and run:<br>
 ### Convert DLC model to QNN(*.bin) format
 Firstly, download SuperResolution AI models dlc files from [SuperResolution AI models](https://aihub.qualcomm.com/mobile/models?domain=Computer+Vision&useCase=Super+Resolution). 
 
-Then, covert the dlc files into QNN(*.bin) files, according to this Link: [Snapdragon® 8 Elite Mobile Devices (Android Phone and Tablet)](https://github.com/quic/ai-engine-direct-helper/blob/main/tools/convert/dlc2bin/README.md#snapdragon-8-elite-mobile-devices-android-phone-and-tablet).
+Then, covert the dlc files into QNN(*.bin) files, according to this Link: [Snapdragon® 8 Elite Mobile Devices (Android Phone and Tablet)](https://github.com/qualcomm/qai-appbuilder/blob/main/tools/convert/dlc2bin/README.md#snapdragon-8-elite-mobile-devices-android-phone-and-tablet).
 
 ### Push files to Android device
 You can copy files into device under MTP mode or use adb commands. 
@@ -48,10 +48,10 @@ sun:/sdcard/AIModels/SuperResolution/quicksrnetmedium $ ls -l
 ### Download and build SuperResolution app source codes
 • Run below command in Windows terminal to download SuperResolution source codes:<br>
 ```
-git clone https://github.com/quic/ai-engine-direct-helper.git --recursive
+git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 ```
-One SuperResolution app source codes are under this folder: [samples/android/SuperResolution](https://github.com/quic/ai-engine-direct-helper/tree/main/samples/android/SuperResolution)<br>
-Another SuperResolution app source codes are under this folder: [samples/android/SuperResolution2](https://github.com/quic/ai-engine-direct-helper/tree/main/samples/android/SuperResolution2).<br>
+One SuperResolution app source codes are under this folder: [samples/android/SuperResolution](https://github.com/qualcomm/qai-appbuilder/tree/main/samples/android/SuperResolution)<br>
+Another SuperResolution app source codes are under this folder: [samples/android/SuperResolution2](https://github.com/qualcomm/qai-appbuilder/tree/main/samples/android/SuperResolution2).<br>
 You can use one of above two SuperResolution apps source codes.<br>
 
 • Copy following 8 .so files from QAIRT SDK to folder SuperResolution\app\libs\arm64-v8a\ :<br>
@@ -67,8 +67,8 @@ C:\Qualcomm\AIStack\QAIRT\{Qualcomm® AI Runtime SDK version}\lib\hexagon-v81\un
 
 ```
 • Under folder SuperResolution\app\src\main\cpp\External\, create new folder QAIAppBuilder and subfolder include.<br>
-Please Copy 2 files ai-engine-direct-helper\src\LibAppBuilder.hpp and ai-engine-direct-helper\src\Lora.hpp to SuperResolution\app\src\main\cpp\External\QAIAppBuilder\include\.<br>
-Please refer to [Build QAI AppBuilder for android](https://github.com/quic/ai-engine-direct-helper/blob/main/BUILD.md) to build appbuilder, and copy generated file libappbuilder.so to folder SuperResolution\app\src\main\cpp\External\QAIAppBuilder\.<br>
+Please Copy 2 files qai-appbuilder\src\LibAppBuilder.hpp and qai-appbuilder\src\Lora.hpp to SuperResolution\app\src\main\cpp\External\QAIAppBuilder\include\.<br>
+Please refer to [Build QAI AppBuilder for android](https://github.com/qualcomm/qai-appbuilder/blob/main/BUILD.md) to build appbuilder, and copy generated file libappbuilder.so to folder SuperResolution\app\src\main\cpp\External\QAIAppBuilder\.<br>
 
 • Get source codes of xtensor and xtl from github:<br>
 ```

--- a/samples/apps/StorySeed/README.md
+++ b/samples/apps/StorySeed/README.md
@@ -15,15 +15,15 @@ This application randomly selects four words from a list of 200 elementary-level
 
 ## Setting Up Environment
 ### Step 1: Install Dependencies
-• Please refer to [Run the large language model on the local NPU](https://github.com/quic/ai-engine-direct-helper/blob/main/samples/genie/python/README.md).
+• Please refer to [Run the large language model on the local NPU](https://github.com/qualcomm/qai-appbuilder/blob/main/samples/genie/python/README.md).
 
-• Please download [GenieAPIService](https://github.com/quic/ai-engine-direct-helper/releases/download/v2.38.0/GenieAPIService_v2.1.0_QAIRT_v2.38.0_v73.zip) and copy the files in it into the directory "GenieAPIService" under the path "ai-engine-direct-helper\samples".
+• Please download [GenieAPIService](https://github.com/qualcomm/qai-appbuilder/releases/download/v2.38.0/GenieAPIService_v2.1.0_QAIRT_v2.38.0_v73.zip) and copy the files in it into the directory "GenieAPIService" under the path "qai-appbuilder\samples".
 
-• Please download [Qwen2.0-7B-SSD Model](https://www.aidevhome.com/data/adh2/models/8380/qwen2_7b_ssd.zip). Extract it and copy the folder 'Qwen2.0-7B-SSD' into the directory 'ai-engine-direct-helper\samples\genie\python\models'.
+• Please download [Qwen2.0-7B-SSD Model](https://www.aidevhome.com/data/adh2/models/8380/qwen2_7b_ssd.zip). Extract it and copy the folder 'Qwen2.0-7B-SSD' into the directory 'qai-appbuilder\samples\genie\python\models'.
 
 • Run the following 2 commands to launch the Service：
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 GenieAPIService\GenieAPIService.exe -c "genie\python\models\Qwen2.0-7B-SSD\config.json"  -l
 ```
 If the service prints the following logs, indicating that GenieAPIService started successfully.
@@ -69,7 +69,7 @@ Note: please make sure fill in the actual chrome version to install chromedriver
 • Enter the directory and execute the python script:
 
 ```
-cd ai-engine-direct-helper\samples\
+cd qai-appbuilder\samples\
 python apps\StorySeed\StorySeed.py
 ```
 
@@ -87,7 +87,7 @@ Genie Service Started
 and DO NOT input phone number or verification code on the Chrome browser.**
 ```
 ⚠️Please input the verification code in Command line, NOT in Browser⚠️
-Try to load cookies from json: C:\codes\ai-engine-direct-helper\samples\apps\StorySeed\red_cookies.json
+Try to load cookies from json: C:\codes\qai-appbuilder\samples\apps\StorySeed\red_cookies.json
 WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
 I0000 00:00:1753436926.115219   12300 voice_transcription.cc:58] Registering VoiceTranscriptionCapability
 Clean all the inactive cookies
@@ -103,7 +103,7 @@ After the story is posted, you can see the update in [Xiaohongshu](https://creat
 ### Note
 • If you want to use another mobile phone number to login, please delete existing file red_cookies.json firstly.
 • Don't start any other GenieAPIService when executing this app.
-• If you want to use another AI model but not 'Qwen2.0-7B-SSD', for example IBM-Granite-v3.1-8B model, please modify the variable MODEL_NAME in StorySeed.py to be "IBM-Granite-v3.1-8B" , and please copy the model files into the directory 'ai-engine-direct-helper\samples\genie\python\models', try below commands to ensure GenieAPIService can be started successfully(remember press Ctrl+C to stop it manually).
+• If you want to use another AI model but not 'Qwen2.0-7B-SSD', for example IBM-Granite-v3.1-8B model, please modify the variable MODEL_NAME in StorySeed.py to be "IBM-Granite-v3.1-8B" , and please copy the model files into the directory 'qai-appbuilder\samples\genie\python\models', try below commands to ensure GenieAPIService can be started successfully(remember press Ctrl+C to stop it manually).
 ```
 GenieAPIService\GenieAPIService.exe -c "genie\python\models\IBM-Granite-v3.1-8B\config.json"  -l
 ```

--- a/samples/apps/StorySeed/StorySeed.py
+++ b/samples/apps/StorySeed/StorySeed.py
@@ -22,7 +22,7 @@ import PIL.Image
 import builtins
 import re
 
-#current location: ai-engine-direct-helper\samples
+#current location: qai-appbuilder\samples
 CURRENT_DIR = os.getcwd()
 RED_APP_DIR = os.path.join(CURRENT_DIR, "apps", "StorySeed")
 IMAGE_SCRIPT_PATH = os.path.join(CURRENT_DIR, "python", "stable_diffusion_v2_1", "stable_diffusion_v2_1.py")

--- a/samples/c++/beit/README.md
+++ b/samples/c++/beit/README.md
@@ -45,7 +45,7 @@ Run the following script to install all required dependencies and tools:
 ```
 Then navigate to:
 ```
-ai-engine-direct-helper/samples/
+qai-appbuilder/samples/
 ```
 Copy the entire **qai_libs/** folder into your local beit/ project directory.
 
@@ -56,13 +56,13 @@ Open a terminal in C:\ai-hub\，and run:
 ```
 .\8.Start_PythonEnv.bat
 pip install py3-wget==1.0.12
-cd ../ai-engine-direct-helper/samples
+cd ../qai-appbuilder/samples
 python python\beit\beit.py
 ```
 **Note: All operations in this step are performed inside the virtual environment py312, which is automatically created and activated by 8.Start_PythonEnv.bat.**
 Then navigate to:
 ```
-ai-engine-direct-helper/samples/python/beit/
+qai-appbuilder/samples/python/beit/
 ```
 Copy the following files into your local beit/ directory:
 * **models/** folder (contains the BEIT model and imagenet_labels.txt files)

--- a/samples/c++/real_esrgan_x4plus/README.md
+++ b/samples/c++/real_esrgan_x4plus/README.md
@@ -17,7 +17,7 @@ During the  Visual Studio installation process, you will be asked to choose the 
 * **Desktop development with C++**.
 
 ##  1.File Download & Setup Instructions
-First, create a directory named `real_esrgan_x4plus` at any location (e.g., ai-engine-direct-helper\samples\c++\real_esrgan_x4plus). 
+First, create a directory named `real_esrgan_x4plus` at any location (e.g., qai-appbuilder\samples\c++\real_esrgan_x4plus). 
 The final project structure should look like this:
 ```plaintext
 real_esrgan_x4plus/
@@ -44,7 +44,7 @@ Run the following script to install all required dependencies and tools:
 ```
 Then navigate to:
 ```
-ai-engine-direct-helper/samples/
+qai-appbuilder/samples/
 ```
 Copy the entire **`qai_libs`/** folder into your local `real_esrgan_x4plus`/ project directory.
 
@@ -55,13 +55,13 @@ Open a terminal in C:\ai-hub\，and run:
 ```
 .\8.Start_PythonEnv.bat
 pip install py3-wget==1.0.12
-cd ../ai-engine-direct-helper/samples
+cd ../qai-appbuilder/samples
 python python\real_esrgan_x4plus\real_esrgan_x4plus.py
 ```
 **Note: All operations in this step are performed inside the virtual environment py312, which is automatically created and activated by 8.Start_PythonEnv.bat.**
 Then navigate to:
 ```
-ai-engine-direct-helper/samples/python/real_esrgan_x4plus/
+qai-appbuilder/samples/python/real_esrgan_x4plus/
 ```
 Copy the following files into your local `real_esrgan_x4plus`/ directory:
 * **`models`/** folder (contains the real_esrgan_x4plus model (`real_esrgan_x4plus.bin`) files)

--- a/samples/fletui/GenieFletUI/android/README.md
+++ b/samples/fletui/GenieFletUI/android/README.md
@@ -18,9 +18,9 @@ Step 1. Start cmd command prompt window and active python virtual environment wi
 ```
 <flet_android_env path>\Scripts\activate
 ```
-Step 2. Go to ai-engine-direct-helper samples path and start GenieFletUI application with below command:
+Step 2. Go to qai-appbuilder samples path and start GenieFletUI application with below command:
 ```
-cd <your path>\ai-engine-direct-helper\samples
+cd <your path>\qai-appbuilder\samples
 python fletui\GenieFletUI\android\GenieFletUI.py
 ```
 

--- a/samples/fletui/GenieFletUI/windows/README.md
+++ b/samples/fletui/GenieFletUI/windows/README.md
@@ -19,9 +19,9 @@ Step 2. Start a new cmd command prompt window and active python virtual environm
 ```
 <myfletenv path>\Scripts\activate
 ```
-Step 3. Go to ai-engine-direct-helper samples path and start GenieFletUI application with below command:
+Step 3. Go to qai-appbuilder samples path and start GenieFletUI application with below command:
 ```
-cd <your path>\ai-engine-direct-helper\samples
+cd <your path>\qai-appbuilder\samples
 python fletui\GenieFletUI\windows\App\GenieFletUI.py
 ```
 
@@ -32,16 +32,16 @@ Step 1. Start cmd command prompt window and active python virtual environment wi
 ```
 <myfletenv path>\Scripts\activate
 ```
-Step 2. Go to ai-engine-direct-helper GenieFletUI path and generate building .spec file with below command:
+Step 2. Go to qai-appbuilder GenieFletUI path and generate building .spec file with below command:
 ```
-cd <your path>\ai-engine-direct-helper\samples\fletui\GenieFletUI\windows\App
+cd <your path>\qai-appbuilder\samples\fletui\GenieFletUI\windows\App
 python GenieFletUI_generate_spec.py
 ```
 Step 3. Build geniefletui with below command:
 ```
 pyinstaller GenieFletUI.spec
 ```
-GenieFletUI.exe will be saved at <your path>\ai-engine-direct-helper\samples\fletui\GenieFletUI\windows\App\dist <br>
+GenieFletUI.exe will be saved at <your path>\qai-appbuilder\samples\fletui\GenieFletUI\windows\App\dist <br>
 
 ## Note
 

--- a/samples/fletui/GenieFletUI/windows/RagTool/README.md
+++ b/samples/fletui/GenieFletUI/windows/RagTool/README.md
@@ -18,9 +18,9 @@ Step 1. Start cmd command prompt window and active python virtual environment wi
 ```
 <myfletenv path>\Scripts\activate
 ```
-Step 2. Go to ai-engine-direct-helper samples path and start ragsavedoc application with below command:
+Step 2. Go to qai-appbuilder samples path and start ragsavedoc application with below command:
 ```
-cd <your path>\ai-engine-direct-helper\samples
+cd <your path>\qai-appbuilder\samples
 python fletui\GenieFletUI\windows\Ragtool\RagSaveDoc.py
 ```
 
@@ -31,16 +31,16 @@ Step 1. Start cmd command prompt window and active python virtual environment wi
 ```
 <myfletenv path>\Scripts\activate
 ```
-Step 2. Go to ai-engine-direct-helper ragsavedoc path and generate building .spec file with below command:
+Step 2. Go to qai-appbuilder ragsavedoc path and generate building .spec file with below command:
 ```
-cd <your path>\ai-engine-direct-helper\samples\fletui\GenieFletUI\windows\Ragtool
+cd <your path>\qai-appbuilder\samples\fletui\GenieFletUI\windows\Ragtool
 python RagSaveDoc_generate_spec.py
 ```
 Step 3. Build ragsavedoc with below command:
 ```
 pyinstaller RagSaveDoc.spec
 ```
-RagSaveDoc will be saved at <your path>\ai-engine-direct-helper\samples\fletui\GenieFletUI\windows\Ragtool\dist <br>
+RagSaveDoc will be saved at <your path>\qai-appbuilder\samples\fletui\GenieFletUI\windows\Ragtool\dist <br>
 
 ## Note
 

--- a/samples/genie/c++/Service/.gitignore
+++ b/samples/genie/c++/Service/.gitignore
@@ -1,4 +1,4 @@
-ai-engine-direct-helper/
+qai-appbuilder/
 build/
 GenieService_v*
 .idea

--- a/samples/genie/c++/Service/src/GenieAPIService/src/config.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/config.h
@@ -65,7 +65,7 @@ inline bool Config::Process()
     bool version{false};
 
     CLI::App app{"Genie API Service - Powerful Local LLM Service"};
-    app.footer("\nSupport: https://github.com/quic/ai-engine-direct-helper");
+    app.footer("\nSupport: https://github.com/qualcomm/qai-appbuilder");
 
     app.add_option("-c,--config_file", config_file, "Path to the config file.");
     app.add_option("--adapter", model_config_.loraAdapter, "the adapter of lora");

--- a/samples/genie/c++/docs/BUILD.md
+++ b/samples/genie/c++/docs/BUILD.md
@@ -69,7 +69,7 @@ The automated build script (`build_android.bat`) will:
 
 Simply run:
 ```cmd
-cd ai-engine-direct-helper\samples\genie\c++
+cd qai-appbuilder\samples\genie\c++
 build_android.bat
 ```
 

--- a/samples/genie/c++/docs/BUILD_ANDROID_README.md
+++ b/samples/genie/c++/docs/BUILD_ANDROID_README.md
@@ -4,7 +4,7 @@
 
 `build_android.bat` is an automated build script for compiling the Android version of libappbuilder.so and GenieAPIService libraries. The script automatically handles dependencies and organizes all build artifacts into the `build_android` folder, keeping the source code directory clean.
 
-**Script Location**: `ai-engine-direct-helper/samples/genie/c++/build_android.bat`
+**Script Location**: `qai-appbuilder/samples/genie/c++/build_android.bat`
 
 ## Features
 
@@ -138,7 +138,7 @@ Follow the prompts to set passwords and certificate information.
 
 ```cmd
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
-cd ai-engine-direct-helper
+cd qai-appbuilder
 ```
 
 ### 2. Configure the Build Script
@@ -260,7 +260,7 @@ This error occurs when Android Studio's embedded JDK is incompatible with the Gr
 
 The automated build script handles JDK compatibility automatically:
 ```cmd
-cd ai-engine-direct-helper\samples\genie\c++
+cd qai-appbuilder\samples\genie\c++
 build_android.bat
 ```
 
@@ -269,7 +269,7 @@ build_android.bat
 If you have JDK 17 installed separately:
 ```cmd
 set JAVA_HOME=C:\Program Files\Java\jdk-17
-cd ai-engine-direct-helper\samples\genie\c++\Android
+cd qai-appbuilder\samples\genie\c++\Android
 gradlew.bat clean assembleRelease
 ```
 
@@ -345,7 +345,7 @@ Automatically builds an Android APK package ready for installation.
 
 ## License
 
-This script follows the same license as the ai-engine-direct-helper project (BSD-3-Clause).
+This script follows the same license as the qai-appbuilder project (BSD-3-Clause).
 
 ## Feedback and Support
 

--- a/samples/genie/c++/docs/BUILD_LINUX.md
+++ b/samples/genie/c++/docs/BUILD_LINUX.md
@@ -34,7 +34,7 @@ sudo apt install -y git cmake build-essential
 
 ```bash
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
-cd ai-engine-direct-helper
+cd qai-appbuilder
 ```
 
 If you already cloned it without `--recursive`, **you must** initialise the

--- a/samples/genie/c++/docs/MODEL_DEPLOYMENT.md
+++ b/samples/genie/c++/docs/MODEL_DEPLOYMENT.md
@@ -5,7 +5,7 @@ You should choose and download models first by following this [Download Link](ht
 The path `models/[MODEL_NAME]/config.json` is recommended. For VLM, Please make the model follow
 the [VLM model layout](#Deployment)
 
-- Windows: move the models to `ai-engine-direct-helper\samples\genie\python\models` path.
+- Windows: move the models to `qai-appbuilder\samples\genie\python\models` path.
 
 - Android: Please push the model files into your device. The model files should be pushed to `/sdcard/GenieModels`.
 

--- a/samples/genie/c++/docs/Qwen2.5-VL-3B-Quickly-Start.md
+++ b/samples/genie/c++/docs/Qwen2.5-VL-3B-Quickly-Start.md
@@ -9,7 +9,7 @@ This section explains how to configure and run the Qwen2.5-VL-3B model in a Wind
 - **Download model files**:<br>
   Visit the website to download the model files for the corresponding
   platform: [Qwen2.5-VL-3B](https://www.aidevhome.com/?id=51) Model Download, and place
-  the downloaded model in the `ai-engine-direct-helper\samples\genie\python\models` directory.
+  the downloaded model in the `qai-appbuilder\samples\genie\python\models` directory.
 
 - **Download the Genie Service Program**:<br>
   Go to the GitHub Releases page to
@@ -17,7 +17,7 @@ This section explains how to configure and run the Qwen2.5-VL-3B model in a Wind
   Releases download page.
 
 - **Extract the file**:<br>
-  Unzip the downloaded compressed package into the project code directory `ai-engine-direct-helper\samples`.
+  Unzip the downloaded compressed package into the project code directory `qai-appbuilder\samples`.
 
 ### 1.2 Starting Services and Running Examples
 
@@ -26,7 +26,7 @@ separately.
 
 ```
 # 1. Entry the directory
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 
 # 2. Start the GenieAPI Service (loading the config file)
 GenieAPIService\GenieAPIService.exe -c "genie\python\models\qwen2.5vl3b\config.json" -l

--- a/samples/genie/python/README.md
+++ b/samples/genie/python/README.md
@@ -33,9 +33,9 @@ pip install uvicorn==0.34.0 pydantic_settings==2.10.1 fastapi==0.115.8 langchain
 ```
 
 ### Step 3: Download models and tokenizer files
-Download the files from the [AI-Hub LLM models](https://github.com/quic/ai-engine-direct-helper/tree/main/samples/genie/python#ai-hub-llm-models) list at the end of this page, save them to following path. <br>
+Download the files from the [AI-Hub LLM models](https://github.com/qualcomm/qai-appbuilder/tree/main/samples/genie/python#ai-hub-llm-models) list at the end of this page, save them to following path. <br>
 ```
-ai-engine-direct-helper\samples\genie\python\models\<model name>
+qai-appbuilder\samples\genie\python\models\<model name>
 ```
 * Select 'Snapdragon® X Elite' as the device for WoS platform while downloading the model.<br>
 * You need to unzip the 'weight_sharing_model_N_of_N.serialized.bin' files from model package and copy them to following path. Download and copy the corresponding 'tokenizer.json' file to the following directory path too. 
@@ -43,15 +43,15 @@ ai-engine-direct-helper\samples\genie\python\models\<model name>
 
 If you want to modify the relative path of the directory where the model file is located, you need to modify the "config.json" file in the corresponding directory of the model to ensure that the 'tokenizer.json', 'htp_backend_ext_config.json' and model files set in the configuration file can be found correctly.
 ```
-ai-engine-direct-helper\samples\genie\python\models\<model name>\config.json
+qai-appbuilder\samples\genie\python\models\<model name>\config.json
 ```
 
-* You can also use your own LLM Genie model (if you have one). Refer to [setup custom model](https://github.com/quic/ai-engine-direct-helper/tree/main/samples/genie/python#setup-custom-model) part for detailed steps.
+* You can also use your own LLM Genie model (if you have one). Refer to [setup custom model](https://github.com/qualcomm/qai-appbuilder/tree/main/samples/genie/python#setup-custom-model) part for detailed steps.
 
 ### Step 4: Switch to samples directory
 Run following commands in Windows terminal:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 ```
 
 ### Step 5: Run service
@@ -135,14 +135,14 @@ The following is the correct change for the 'tokenizer.json' file of 'Phi-3.5-Mi
 | [Llama 3.1 8B](https://www.aidevhome.com/data/adh2/models/suggested/llama3.1-8b-8380-qnn2.38.zip) | [llama3.1-8b-8380-qnn2.38.zip](https://www.aidevhome.com/data/adh2/models/suggested/llama3.1-8b-8380-qnn2.38.zip) |
 
 ### Setup custom model:
-You can create a subdirectory in the path "ai-engine-direct-helper\samples\genie\python\models\" for your own model and customize the "config.json", "prompt.conf" or "prompt.json" files for your model. Both files should be stored in the same directory as your model files. Then use the new directory which you've created as your model name, the name can be used in the client application. <br>
+You can create a subdirectory in the path "qai-appbuilder\samples\genie\python\models\" for your own model and customize the "config.json", "prompt.conf" or "prompt.json" files for your model. Both files should be stored in the same directory as your model files. Then use the new directory which you've created as your model name, the name can be used in the client application. <br>
 Note: "prompt.conf" is for old version GenieAPIServcie(< 2.0). Since GenieAPIServcie 2.0, we use "prompt.json" to replace it.<br>
 
 1. config.json : Model configuration file. It includes key parameters for the model. You can get several template configuration files for popular models such as Llama 2 & 3, Phi 3.5, Qwen 2 from here:<br>
 https://github.com/quic/ai-hub-apps/tree/main/tutorials/llm_on_genie/configs/genie <br><br>
 You need to make sure that the following parameters in the configuration file point to the correct file path. <br>
 a. tokenizer: The path to the model 'tokenizer.json' file. <br>
-b. extensions: The path to Genie extension configuration file. You can find it from path: 'ai-engine-direct-helper\samples\genie\python\config\htp_backend_ext_config.json'<br>
+b. extensions: The path to Genie extension configuration file. You can find it from path: 'qai-appbuilder\samples\genie\python\config\htp_backend_ext_config.json'<br>
 c. ctx-bins: The path to model context bin files(ctx-bins). Usually a model has 3~5 context bin files. <br>
 d. forecast-prefix-name:The path to the directory where SSD model 'kv-cache.primary.qnn-htp' file is stored. Only SSD model needs this parameter.<br>
 e. other parameters: Set other parameters according to your model. <br>

--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -28,12 +28,12 @@ pip install qai_hub_models==0.30.2 huggingface_hub==0.33.1 Pillow==10.4.0 numpy=
 ### Step 3: Run Model
 Run below commands in Windows terminal:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 python <Python script for running model> <Parameter of Python script>
 ```
 Where `<Python script for running model>` is the Python script you want to run. For example, if you want to run `stable_diffusion_v2_1`, you can run below command:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 python python\stable_diffusion_v2_1\stable_diffusion_v2_1.py --prompt "spectacular view of northern lights from Alaska"
 ```
 

--- a/samples/python/easy_ocr/README.md
+++ b/samples/python/easy_ocr/README.md
@@ -4,7 +4,7 @@
 This is sample code for using AppBuilder to load easyocr QNN model to HTP and execute optical character recognition (OCR) inference to detect and extract text from input images.
 
 ###
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 python python\easyocr\easy_ocr.py
 
 ####Resources:

--- a/samples/python/mediapipe_hand/README.md
+++ b/samples/python/mediapipe_hand/README.md
@@ -14,9 +14,9 @@ This application supports camera frame online inference (default) and jpg image 
 <br><br>
 
 # 2. Command
-go to <ai-engine-direct-helper> path:
+go to <qai-appbuilder> path:
 ```
-cd <ai-engine-direct-helper>\samples\
+cd <qai-appbuilder>\samples\
 ```
 
 ## Option 1: launch camera app and recognize hand (end_user mode by default) without controlling audio playback:

--- a/samples/python/mediapipe_hand/mediapipe_hand.py
+++ b/samples/python/mediapipe_hand/mediapipe_hand.py
@@ -802,7 +802,7 @@ def capture_and_display_processed_frames(
     if not capture.isOpened():
         raise ValueError("Unable to open video capture.")
 
-    # image_256x256 = Image.open("C:\\Users\\WM\\Desktop\\QAI\\ai-engine-direct-helper\\samples\\python\\mediapipehand\\input.jpg")
+    # image_256x256 = Image.open("C:\\Users\\WM\\Desktop\\QAI\\qai-appbuilder\\samples\\python\\mediapipehand\\input.jpg")
     # test_Frame256x256 = np.array(image_256x256.convert("RGB"))
 
     frame_count = 0
@@ -867,14 +867,14 @@ def main():
         "--imagefile",
         type=str,
         default=None,
-        # default="C:\\Users\\WM\\Desktop\\QAI\\ai-engine-direct-helper\\samples\\python\\mediapipehand\\input.jpg",
+        # default="C:\\Users\\WM\\Desktop\\QAI\\qai-appbuilder\\samples\\python\\mediapipehand\\input.jpg",
         help="image file path",
     )
     parser.add_argument(
         "--audiofile",
         type=str,
         default=None,
-        # default="C:\\Users\\WM\\Desktop\\QAI\\ai-engine-direct-helper\\samples\\python\\mediapipehand\\sky.wav",
+        # default="C:\\Users\\WM\\Desktop\\QAI\\qai-appbuilder\\samples\\python\\mediapipehand\\sky.wav",
         help="audio file path",
     )
     parser.add_argument(

--- a/samples/python/real_esrgan_x4plus/README.md
+++ b/samples/python/real_esrgan_x4plus/README.md
@@ -4,8 +4,8 @@
 This is sample code for using AppBuilder to load real_esrgan_x4plus QNN model to HTP and execute inference to generate image. 
 
 ## Setup AppBuilder environment and prepare QNN SDK libraries by referring to the links below: 
-https://github.com/quic/ai-engine-direct-helper/blob/main/README.md <br>
-https://github.com/quic/ai-engine-direct-helper/blob/main/docs/user_guide.md
+https://github.com/qualcomm/qai-appbuilder/blob/main/README.md <br>
+https://github.com/qualcomm/qai-appbuilder/blob/main/docs/user_guide.md
 
 ## real_esrgan_x4plus QNN models
 The quantized real_esrgan_x4plus QNN model's input resolution is 128x128 from Qualcomm® AI Hub:
@@ -40,7 +40,7 @@ C:\ai-hub\real_esrgan_x4plus\models\real_esrgan_x4plus.bin
 
 ## Run the sample code
 Download the sample code from the following link:
-https://github.com/quic/ai-engine-direct-helper/blob/main/Samples/real_esrgan_x4plus/real_esrgan_x4plus.py
+https://github.com/qualcomm/qai-appbuilder/blob/main/Samples/real_esrgan_x4plus/real_esrgan_x4plus.py
 
 After downloaded the sample code, please copy it to the following path:
 ```

--- a/samples/webui/README.md
+++ b/samples/webui/README.md
@@ -28,7 +28,7 @@ pip install gradio==5.35.0 qai_hub_models==0.30.2 huggingface_hub==0.33.1 Pillow
 ### Step 3: Switch to samples directory:
 Run below commands in Windows terminal:
 ```
-cd ai-engine-direct-helper\samples
+cd qai-appbuilder\samples
 ```
 
 ### Step 4: Run WebUI Apps:

--- a/tools/launcher/.gitignore
+++ b/tools/launcher/.gitignore
@@ -1,4 +1,4 @@
-ai-engine-direct-helper/
+qai-appbuilder/
 tools/
 _pycache/
 env/.pixi/

--- a/tools/launcher/4.Start_GenieAPIService.bat
+++ b/tools/launcher/4.Start_GenieAPIService.bat
@@ -20,7 +20,7 @@ echo Start Genie Service...
     )
 
     echo Starting C++ Genie Service...
-    cd ai-engine-direct-helper\samples\
+    cd qai-appbuilder\samples\
     echo Please keep this window open. Genie Service is running
     powershell -Command "GenieAPIService\GenieAPIService.exe -c genie\python\models\%MODEL_CONFIG%\config.json"
     echo Genie API Service Started.

--- a/tools/launcher/README.md
+++ b/tools/launcher/README.md
@@ -21,7 +21,7 @@ Note: If the following automatic installation script doesn't work for some reaso
 
 There are two ways to get our Windows batch scripts:
 1. Download the compressed package through [QAI_Launcher_v2.0.0.zip](https://github.com/qualcomm/qai-appbuilder/releases/download/v2.38.0/QAI_Launcher_v2.0.0.zip)  and reduce the compression; <br>
-2. Download this git repository, you can find these scripts from the path 'ai-engine-direct-helper/tools/launcher'; <br>
+2. Download this git repository, you can find these scripts from the path 'qai-appbuilder/tools/launcher'; <br>
 
 ### 2. Run these script one by one
 

--- a/tools/launcher/env/pixi.toml
+++ b/tools/launcher/env/pixi.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 [tasks]
 install-tools = { cmd = ["python", "utils/Install_Tools.py"], cwd = ".."}
 install-vs = { cmd = ["python", "utils/Install_Visual_Studio.py"], cwd = ".."}
-install-qai-appbuilder = { cmd = ["python", "python/setup.py"], cwd = "../ai-engine-direct-helper/samples/"}
+install-qai-appbuilder = { cmd = ["python", "python/setup.py"], cwd = "../qai-appbuilder/samples/"}
 install-model = { cmd = ["python", "utils/Install_LLM_Models.py"], cwd = ".."}
 install-langflow = { cmd = "uv pip install langflow==1.7.1 --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"}
-webui-imagerepair = { cmd = "python ./webui/ImageRepairApp.py", cwd = "../ai-engine-direct-helper/samples"}
-webui-stable-diffusion = { cmd = "python ./webui/StableDiffusionApp.py", cwd = "../ai-engine-direct-helper/samples"}
-webui-genie = { cmd = "python ./webui/GenieWebUI.py", cwd = "../ai-engine-direct-helper/samples"}
+webui-imagerepair = { cmd = "python ./webui/ImageRepairApp.py", cwd = "../qai-appbuilder/samples"}
+webui-stable-diffusion = { cmd = "python ./webui/StableDiffusionApp.py", cwd = "../qai-appbuilder/samples"}
+webui-genie = { cmd = "python ./webui/GenieWebUI.py", cwd = "../qai-appbuilder/samples"}
 
 [dependencies]
 python = "3.12.8.*"

--- a/tools/launcher/utils/Install_LLM_Models.py
+++ b/tools/launcher/utils/Install_LLM_Models.py
@@ -18,7 +18,7 @@ models = {
 
 def main():
     ensure_windows_tools()
-    base_dir = os.path.join("ai-engine-direct-helper", "samples", "genie", "python", "models")
+    base_dir = os.path.join("qai-appbuilder", "samples", "genie", "python", "models")
     os.makedirs(base_dir, exist_ok=True)
     proxy = None
 

--- a/tools/launcher/utils/Install_Tools.py
+++ b/tools/launcher/utils/Install_Tools.py
@@ -12,7 +12,7 @@ def copy_tools():
     try:
         script_dir = os.path.dirname(".")
         source_base = os.path.join(script_dir, "tools")
-        target_base = os.path.join(script_dir, "ai-engine-direct-helper", "samples", "tools")
+        target_base = os.path.join(script_dir, "qai-appbuilder", "samples", "tools")
         
         dirs_to_check = ["aria2c", "wget"]        
         os.makedirs(target_base, exist_ok=True)
@@ -41,8 +41,8 @@ def copy_tools():
 def install_GenieAPIService():
     tools_dir = "tools"
     zip_file = os.path.join(tools_dir, "GenieAPIService_Stable_QAIRT_v73.zip")
-    extract_root = os.path.join("ai-engine-direct-helper", "samples")
-    extract_dir = os.path.join("ai-engine-direct-helper", "samples", "GenieAPIService")
+    extract_root = os.path.join("qai-appbuilder", "samples")
+    extract_dir = os.path.join("qai-appbuilder", "samples", "GenieAPIService")
 
     if os.path.exists(tools_dir):
         print("tools directory already exists")
@@ -80,7 +80,7 @@ def install_GenieAPIService():
     #    shutil.rmtree(android_root)
 
 def install_QAIRT():
-    extract_root = os.path.join("ai-engine-direct-helper", "samples", "qai_libs")
+    extract_root = os.path.join("qai-appbuilder", "samples", "qai_libs")
     zip_file = os.path.join(extract_root, "QAIRT_Runtime_2.38.0_v73.zip")
 
     if os.path.exists(extract_root):
@@ -128,15 +128,15 @@ def install_git():
 
 def clone_or_update_repo():
     try:
-        repo_dir = "ai-engine-direct-helper"
+        repo_dir = "qai-appbuilder"
 
         if not os.path.exists(repo_dir):
-            print("Cloning ai-engine-direct-helper repository...")
+            print("Cloning qai-appbuilder repository...")
             
             subprocess.run(["git", "clone", "https://github.com/qualcomm/qai-appbuilder.git", "--depth=1"], check=True)
             print(f"Repository cloned to {repo_dir}")
         else:
-            print(f"ai-engine-direct-helper repository already exists at {repo_dir}. Pulling latest changes...")
+            print(f"qai-appbuilder repository already exists at {repo_dir}. Pulling latest changes...")
             
             subprocess.run(["git", "pull"], check=True, cwd=repo_dir)
             print("Latest changes pulled.")

--- a/tools/launcher_linux/1.Install_QAI_Appbuilder.sh
+++ b/tools/launcher_linux/1.Install_QAI_Appbuilder.sh
@@ -42,7 +42,7 @@ cd ..
 if command -v pixi &> /dev/null; then
     cd "$scriptPath/env" || exit
     
-    if compgen -G "$scriptPath/ai-engine-direct-helper/dist/qai_appbuilder-*.whl" > /dev/null; then
+    if compgen -G "$scriptPath/qai-appbuilder/dist/qai_appbuilder-*.whl" > /dev/null; then
         echo "Wheel file already exists, skipping build..."
     else
         echo "Building QAI AppBuilder..."

--- a/tools/launcher_linux/2.Install_LLM_Models.sh
+++ b/tools/launcher_linux/2.Install_LLM_Models.sh
@@ -15,7 +15,7 @@ echo "Installing large language model..."
 cd env || exit
 
 # 执行 pixi 命令
-if [ -f "$currentDir/ai-engine-direct-helper/samples/genie/python/models/IBM-Granite-v3.1-8B/weight_sharing_model_4_of_5.serialized.bin" ]; then
+if [ -f "$currentDir/qai-appbuilder/samples/genie/python/models/IBM-Granite-v3.1-8B/weight_sharing_model_4_of_5.serialized.bin" ]; then
     echo "LLM Models already exists, skipping download..."
 else
     echo "Download LLM Models..."

--- a/tools/launcher_linux/README.md
+++ b/tools/launcher_linux/README.md
@@ -21,7 +21,7 @@ Note: If the following automatic installation script doesn't work for some reaso
 
 There are two ways to get our Windows batch scripts:
 1. Download the compressed package through [QAI_Launcher_Linux_v2.0.0.zip](https://github.com/qualcomm/qai-appbuilder/releases/download/v2.38.0/QAI_Launcher_Linux_v2.0.0.zip)  and reduce the compression; <br>
-2. Download this git repository, you can find these scripts from the path 'ai-engine-direct-helper/tools/launcher'; <br>
+2. Download this git repository, you can find these scripts from the path 'qai-appbuilder/tools/launcher'; <br>
 
 ### 3. Set environment
 

--- a/tools/launcher_linux/env/pixi.toml
+++ b/tools/launcher_linux/env/pixi.toml
@@ -6,14 +6,14 @@ version = "0.1.0"
 
 [tasks]
 install-tools = { cmd = ["python", "utils/Install_Tools.py"], cwd = ".."}
-build-qai-appbuilder = { cmd = ["python", "setup.py", "bdist_wheel", "--toolchains", "aarch64-oe-linux-gcc11.2", "--hexagonarch", "73"], cwd = "../ai-engine-direct-helper"}
-install-qai-appbuilder = { cmd = "bash -lc 'pip install ./qai_appbuilder-*.whl --force-reinstall'", cwd = "../ai-engine-direct-helper/dist/"}
+build-qai-appbuilder = { cmd = ["python", "setup.py", "bdist_wheel", "--toolchains", "aarch64-oe-linux-gcc11.2", "--hexagonarch", "73"], cwd = "../qai-appbuilder"}
+install-qai-appbuilder = { cmd = "bash -lc 'pip install ./qai_appbuilder-*.whl --force-reinstall'", cwd = "../qai-appbuilder/dist/"}
 install-model = { cmd = ["python", "utils/Install_LLM_Models.py"], cwd = ".."}
 install-langflow = { cmd = "uv pip install langflow==1.5.0 --trusted-host=pypi.org --trusted-host=files.pythonhosted.org"}
-start-GenieAPIService = { cmd = ["python", "genie/python/GenieAPIService.py", "--modelname", "IBM-Granite-v3.1-8B", "--loadmodel", "--profile"], cwd = "../ai-engine-direct-helper/samples/"}
-webui-imagerepair = { cmd = "python ./webui/ImageRepairApp.py", cwd = "../ai-engine-direct-helper/samples"}
-webui-stable-diffusion = { cmd = "python ./webui/StableDiffusionApp.py", cwd = "../ai-engine-direct-helper/samples"}
-webui-genie = { cmd = "python ./webui/GenieWebUI.py", cwd = "../ai-engine-direct-helper/samples"}
+start-GenieAPIService = { cmd = ["python", "genie/python/GenieAPIService.py", "--modelname", "IBM-Granite-v3.1-8B", "--loadmodel", "--profile"], cwd = "../qai-appbuilder/samples/"}
+webui-imagerepair = { cmd = "python ./webui/ImageRepairApp.py", cwd = "../qai-appbuilder/samples"}
+webui-stable-diffusion = { cmd = "python ./webui/StableDiffusionApp.py", cwd = "../qai-appbuilder/samples"}
+webui-genie = { cmd = "python ./webui/GenieWebUI.py", cwd = "../qai-appbuilder/samples"}
 
 [dependencies]
 python = "3.12.8.*"

--- a/tools/launcher_linux/utils/Install_LLM_Models.py
+++ b/tools/launcher_linux/utils/Install_LLM_Models.py
@@ -29,7 +29,7 @@ def download_with_wget(url, dest_path, proxy=None):
 
 def main():
     # ensure_windows_tools()
-    base_dir = os.path.join("ai-engine-direct-helper", "samples", "genie", "python", "models")
+    base_dir = os.path.join("qai-appbuilder", "samples", "genie", "python", "models")
     os.makedirs(base_dir, exist_ok=True)
     proxy = None
 

--- a/tools/launcher_linux/utils/Install_Tools.py
+++ b/tools/launcher_linux/utils/Install_Tools.py
@@ -20,7 +20,7 @@ def download_with_wget(url, dest_path, proxy=None):
         return False
 
 def install_QAIRT():
-    extract_root = os.path.join("ai-engine-direct-helper", "samples", "qai_libs")
+    extract_root = os.path.join("qai-appbuilder", "samples", "qai_libs")
     zip_file = os.path.join(extract_root, "QAIRT_Runtime_2.38.0_v73.zip")
 
     if os.path.exists(extract_root):
@@ -62,15 +62,15 @@ def install_git():
 
 def clone_or_update_repo():
     try:
-        repo_dir = "ai-engine-direct-helper"
+        repo_dir = "qai-appbuilder"
 
         if not os.path.exists(repo_dir):
-            print("Cloning ai-engine-direct-helper repository...")
+            print("Cloning qai-appbuilder repository...")
             
             subprocess.run(["git", "clone", "https://github.com/qualcomm/qai-appbuilder.git", "--recursive"], check=True)
             print(f"Repository cloned to {repo_dir}")
         else:
-            print(f"ai-engine-direct-helper repository already exists at {repo_dir}. Pulling latest changes...")
+            print(f"qai-appbuilder repository already exists at {repo_dir}. Pulling latest changes...")
             
             subprocess.run(["git", "pull"], check=True, cwd=repo_dir)
             print("Latest changes pulled.")
@@ -85,7 +85,7 @@ def clone_or_update_repo():
         return False
 
 def install_qai_appbuilder():
-    extract_root = os.path.join("ai-engine-direct-helper", "samples", "qai_libs")
+    extract_root = os.path.join("qai-appbuilder", "samples", "qai_libs")
     zip_file = os.path.join(extract_root, "qai_appbuilder-2.38.0-cp312-cp312-linux_aarch64.whl")
 
     if os.path.exists(extract_root):

--- a/tools/skills/knowledge-skills/genie_api_service/SKILL.md
+++ b/tools/skills/knowledge-skills/genie_api_service/SKILL.md
@@ -73,4 +73,4 @@ metadata: {"openclaw":{"emoji":"🧞","always":true}}
 **适用问题：** 服务启动失败、模型加载失败、NPU不可用、推理速度慢、流式输出问题、多模态图像识别、Android服务停止、工具调用失效、历史记录丢失、端口占用、文本乱码、Bug报告、技术支持
 **关键词：** 问题、错误、故障、解决方案、troubleshooting、Bug、技术支持
 
-GitHub: https://github.com/quic/ai-engine-direct-helper
+GitHub: https://github.com/qualcomm/qai-appbuilder

--- a/tools/skills/knowledge-skills/genie_api_service/docs/05_build_from_source.md
+++ b/tools/skills/knowledge-skills/genie_api_service/docs/05_build_from_source.md
@@ -77,7 +77,7 @@ cmake -S .. -B . -A ARM64 -DUSE_GGUF=ON -DUSE_MNN=ON
 ### 设置环境变量与路径（Windows 主机构建 Android）
 
 ```bat
-cd ai-engine-direct-helper\samples\genie\c++\Service
+cd qai-appbuilder\samples\genie\c++\Service
 Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.42.0.251225
 set PATH=%PATH%;C:\Programs\android-ndk-r26d\toolchains\llvm\prebuilt\windows-x86_64\bin
 Set NDK_ROOT=C:/Programs/android-ndk-r26d/
@@ -88,7 +88,7 @@ Set ANDROID_NDK_ROOT=%NDK_ROOT%
 
 Android 构建前需要先编译 `libappbuilder`（详见项目根目录的 [BUILD](https://github.com/qualcomm/qai-appbuilder/blob/main/BUILD.md) 说明），并将生成的 `libappbuilder.so` 放到：
 
-`ai-engine-direct-helper\samples\genie\c++\Service`
+`qai-appbuilder\samples\genie\c++\Service`
 
 ### 构建 GenieAPIService（Android）
 
@@ -105,7 +105,7 @@ copy "obj\local\arm64-v8a\*.so" "libs\arm64-v8a" /Y
 
 ### 构建 Android App（Android Studio）
 
-1. 使用 Android Studio 打开：`ai-engine-direct-helper\samples\genie\c++\Android`
+1. 使用 Android Studio 打开：`qai-appbuilder\samples\genie\c++\Android`
 2. 菜单 **Build** → **Generate Signed App Bundle / APK** → 选择 **APK**
 3. 选择签名密钥并完成构建
 4. 在 `...\Android\app\release` 目录获取 `app-release.apk`

--- a/tools/skills/knowledge-skills/genie_api_service/docs/06_api_reference_and_tools.md
+++ b/tools/skills/knowledge-skills/genie_api_service/docs/06_api_reference_and_tools.md
@@ -331,4 +331,4 @@ wav.exe test.wav
 ```
 输入命令后，长按 [空格] 键进行录音。
 
-GitHub: https://github.com/quic/ai-engine-direct-helper
+GitHub: https://github.com/qualcomm/qai-appbuilder

--- a/tools/skills/knowledge-skills/qai_app_builder/docs/02_env_setup_win_linux.md
+++ b/tools/skills/knowledge-skills/qai_app_builder/docs/02_env_setup_win_linux.md
@@ -60,7 +60,7 @@ https://aka.ms/vs/17/release/vc_redist.arm64.exe
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # 如果已克隆，更新代码
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 
@@ -108,7 +108,7 @@ pip3 install numpy pillow opencv-python
 git clone https://github.com/qualcomm/qai-appbuilder.git --recursive
 
 # 如果已克隆，更新代码
-cd ai-engine-direct-helper
+cd qai-appbuilder
 git pull --recurse-submodules
 ```
 

--- a/tools/skills/qai-runner-skill/setup/ubuntu/README.md
+++ b/tools/skills/qai-runner-skill/setup/ubuntu/README.md
@@ -60,7 +60,7 @@ Then execute end-to-end:
 - precheck and source env
 - detect SoC/model and DSP_ARCH using qnn-platform-validator
 - set PRODUCT_SOC/DSP_ARCH and export ADSP_LIBRARY_PATH + LD_LIBRARY_PATH
-- clone/pull ai-engine-direct-helper with recursive submodules
+- clone/pull qai-appbuilder with recursive submodules
 - build wheel (python3 setup.py bdist_wheel)
 - pip install generated wheel
 - run verification commands from SOP

--- a/tools/skills/qai-runner-skill/setup/ubuntu/qaiappbuilder_linux_install_sop.md
+++ b/tools/skills/qai-runner-skill/setup/ubuntu/qaiappbuilder_linux_install_sop.md
@@ -1,7 +1,7 @@
 # QAI AppBuilder Install SOP (Reusable)
 
 ## Purpose
-Install `qai_appbuilder` from source (`ai-engine-direct-helper`) on a target device/environment with QAIRT, then verify DSP backend readiness.
+Install `qai_appbuilder` from source (`qai-appbuilder`) on a target device/environment with QAIRT, then verify DSP backend readiness.
 
 ## Required Inputs (ask before install)
 1. `target_device`: `local` or remote host/IP
@@ -16,7 +16,7 @@ Example from this run:
 - `install_path=/home/ubuntu/Test/qaiappbuilder`
 
 ## Source Repo
-- `https://github.com/quic/ai-engine-direct-helper.git`
+- `https://github.com/qualcomm/qai-appbuilder.git`
 
 ## 1) Precheck and Environment
 ```bash
@@ -66,13 +66,13 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$QNN_SDK_ROOT/lib/aarch64-oe-linux-
 set -euo pipefail
 
 INSTALL_BASE="<ABS_INSTALL_PATH>"
-REPO_DIR="$INSTALL_BASE/ai-engine-direct-helper"
+REPO_DIR="$INSTALL_BASE/qai-appbuilder"
 VENV_PATH="<ABS_VENV_PATH>"
 
 mkdir -p "$INSTALL_BASE"
 
 if [ ! -d "$REPO_DIR/.git" ]; then
-  git clone --recurse-submodules https://github.com/quic/ai-engine-direct-helper.git "$REPO_DIR"
+  git clone --recurse-submodules https://github.com/qualcomm/qai-appbuilder.git "$REPO_DIR"
 fi
 
 git -C "$REPO_DIR" pull --recurse-submodules
@@ -118,7 +118,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$QNN_SDK_ROOT/lib/aarch64-oe-linux-gcc11
 - DSP architecture: `V73` (`DSP_ARCH=73`)
 - Installed version: `qai_appbuilder 2.45.0`
 - Install location: `/home/ubuntu/Test/qairt/pyqairt/lib/python3.10/site-packages`
-- Repo path: `/home/ubuntu/Test/qaiappbuilder/ai-engine-direct-helper`
+- Repo path: `/home/ubuntu/Test/qaiappbuilder/qai-appbuilder`
 
 ## Troubleshooting
 - `aienv.sh missing`: run QAIRT bootstrap SOP first (`QAIRT_SETUP_SOP.md`).

--- a/tools/skills/qai-runner-skill/setup/win_installer/scripts/setup_qairt_env.py
+++ b/tools/skills/qai-runner-skill/setup/win_installer/scripts/setup_qairt_env.py
@@ -273,7 +273,7 @@ def install_python_deps(root):
         {
             "label": "qai_appbuilder (x64 wheel)",
             "packages": [
-                ("https://github.com/quic/ai-engine-direct-helper/releases/download/v2.45.0/qai_appbuilder-2.45.0-cp310-cp310-win_amd64.whl", "qai_appbuilder"),
+                ("https://github.com/qualcomm/qai-appbuilder/releases/download/v2.45.0/qai_appbuilder-2.45.0-cp310-cp310-win_amd64.whl", "qai_appbuilder"),
             ],
         },
         # ── Batch 2: Core numerical + ONNX (pin numpy first) ──────────────


### PR DESCRIPTION
## Summary

Update all repository URL and directory name references following the migration from `quic/ai-engine-direct-helper` to `qualcomm/qai-appbuilder`.

## Changes

- Updated `git clone` URL: `https://github.com/quic/ai-engine-direct-helper.git` → `https://github.com/qualcomm/qai-appbuilder.git`
- Updated cloned directory name references: `ai-engine-direct-helper` → `qai-appbuilder`
- Updated repository links: `https://github.com/quic/ai-engine-direct-helper` → `https://github.com/qualcomm/qai-appbuilder`

## Affected Files (48 files)

Documentation, README files, scripts, configuration files, and source files across the repository.

Closes #118
