### PR TITLE
ci: GitHub Actions CI/CD pipeline + 4 source-level fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,42 @@ jobs:
       # front and exporting its env via GITHUB_ENV makes the build
       # robust to that. ARM64EC binaries link against the ARM64 toolset
       # so amd64_arm64 is the correct vcvars arch.
+      #
+      # Inlined instead of using ilammy/msvc-dev-cmd@v1 because the
+      # qualcomm/qai-appbuilder enterprise GitHub Actions allowlist
+      # rejects third-party actions not in its policy. vcvarsall.bat
+      # comes with VS itself on the windows-2022 hosted runner.
       - name: Setup MSVC (amd64_arm64)
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: amd64_arm64
+        shell: pwsh
+        run: |
+          $vsRoot = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          if (-not (Test-Path $vsRoot)) {
+            $vsRoot = "C:\Program Files\Microsoft Visual Studio\2022\Community"
+          }
+          if (-not (Test-Path $vsRoot)) {
+            $vsRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+          }
+          $vcvars = Join-Path $vsRoot "VC\Auxiliary\Build\vcvarsall.bat"
+          if (-not (Test-Path $vcvars)) {
+            Write-Error "vcvarsall.bat not found under $vsRoot"
+            exit 1
+          }
+          # Diff env before/after vcvarsall so we know which keys to export.
+          $before = cmd /c "set"
+          $after  = cmd /c "`"$vcvars`" amd64_arm64 && set"
+          $beforeMap = @{}
+          foreach ($line in $before) {
+            if ($line -match '^([^=]+)=(.*)$') { $beforeMap[$matches[1]] = $matches[2] }
+          }
+          foreach ($line in $after) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              $k = $matches[1]; $v = $matches[2]
+              if (-not $beforeMap.ContainsKey($k) -or $beforeMap[$k] -ne $v) {
+                "$k=$v" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+              }
+            }
+          }
+          Write-Host "MSVC env staged from $vcvars (amd64_arm64)"
 
       - name: Setup QNN SDK
         uses: ./.github/actions/setup-qnn-sdk
@@ -432,10 +464,25 @@ jobs:
 
       - name: Setup Android NDK r26d
         id: ndk
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26d
-          add-to-path: false
+        # Inlined instead of using nttld/setup-ndk@v1 because the
+        # qualcomm/qai-appbuilder enterprise GitHub Actions allowlist
+        # rejects third-party actions not in its policy. The Linux NDK
+        # zip is a public download from Google.
+        shell: bash
+        run: |
+          ver="r26d"
+          install_dir="${RUNNER_TEMP}/android-ndk-${ver}"
+          zip_path="${RUNNER_TEMP}/android-ndk-${ver}.zip"
+          if [ ! -d "${install_dir}/android-ndk-${ver}" ]; then
+            curl -fsSL -o "${zip_path}" "https://dl.google.com/android/repository/android-ndk-${ver}-linux.zip"
+            mkdir -p "${install_dir}"
+            unzip -q "${zip_path}" -d "${install_dir}"
+            rm -f "${zip_path}"
+          fi
+          ndk_path="${install_dir}/android-ndk-${ver}"
+          test -x "${ndk_path}/ndk-build" || { echo "ndk-build missing at ${ndk_path}"; exit 1; }
+          echo "ndk-path=${ndk_path}" >> "$GITHUB_OUTPUT"
+          echo "Android NDK ${ver} ready at ${ndk_path}"
 
       - name: Setup QNN SDK
         uses: ./.github/actions/setup-qnn-sdk
@@ -558,9 +605,36 @@ jobs:
           git submodule update --init --depth 1 --recursive samples/genie/c++/External
 
       - name: Setup MSVC (amd64_arm64)
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: amd64_arm64
+        shell: pwsh
+        # See build-windows-x64 for rationale of inlining.
+        run: |
+          $vsRoot = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          if (-not (Test-Path $vsRoot)) {
+            $vsRoot = "C:\Program Files\Microsoft Visual Studio\2022\Community"
+          }
+          if (-not (Test-Path $vsRoot)) {
+            $vsRoot = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools"
+          }
+          $vcvars = Join-Path $vsRoot "VC\Auxiliary\Build\vcvarsall.bat"
+          if (-not (Test-Path $vcvars)) {
+            Write-Error "vcvarsall.bat not found under $vsRoot"
+            exit 1
+          }
+          $before = cmd /c "set"
+          $after  = cmd /c "`"$vcvars`" amd64_arm64 && set"
+          $beforeMap = @{}
+          foreach ($line in $before) {
+            if ($line -match '^([^=]+)=(.*)$') { $beforeMap[$matches[1]] = $matches[2] }
+          }
+          foreach ($line in $after) {
+            if ($line -match '^([^=]+)=(.*)$') {
+              $k = $matches[1]; $v = $matches[2]
+              if (-not $beforeMap.ContainsKey($k) -or $beforeMap[$k] -ne $v) {
+                "$k=$v" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+              }
+            }
+          }
+          Write-Host "MSVC env staged from $vcvars (amd64_arm64)"
 
       - name: Setup QNN SDK
         uses: ./.github/actions/setup-qnn-sdk
@@ -791,10 +865,28 @@ jobs:
 
       - name: Setup Android NDK r26d
         id: ndk
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26d
-          add-to-path: false
+        # Inlined instead of using nttld/setup-ndk@v1 because the
+        # qualcomm/qai-appbuilder enterprise GitHub Actions allowlist
+        # rejects third-party actions not in its policy. The Windows
+        # NDK zip is a public download from Google.
+        shell: pwsh
+        run: |
+          $ver = "r26d"
+          $installDir = Join-Path $env:RUNNER_TEMP "android-ndk-$ver"
+          $zipPath    = Join-Path $env:RUNNER_TEMP "android-ndk-$ver.zip"
+          $ndkPath    = Join-Path $installDir "android-ndk-$ver"
+          if (-not (Test-Path $ndkPath)) {
+            Invoke-WebRequest -Uri "https://dl.google.com/android/repository/android-ndk-$ver-windows.zip" -OutFile $zipPath -UseBasicParsing
+            New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+            Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
+            Remove-Item $zipPath -Force
+          }
+          if (-not (Test-Path (Join-Path $ndkPath "ndk-build.cmd"))) {
+            Write-Error "ndk-build.cmd missing at $ndkPath"
+            exit 1
+          }
+          "ndk-path=$ndkPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "Android NDK $ver ready at $ndkPath"
 
       - name: Setup QNN SDK
         uses: ./.github/actions/setup-qnn-sdk
@@ -872,53 +964,3 @@ jobs:
           path: samples/genie/c++/build_android/output/apk/*.apk
           if-no-files-found: ignore
 
-  release:
-    name: Publish GitHub Release
-    # Temporarily disabled — re-enable once all build jobs (especially
-    # Genie Service with USE_GGUF) are stable. To re-enable, change the
-    # condition back to:
-    #   if: startsWith(github.ref, 'refs/tags/v')
-    if: false
-    needs:
-      - build-windows-x64
-      - build-windows-arm64
-      - build-linux-arm64
-      # - build-android-arm64v8a   # disabled until upstream fixes SVC main.cpp on Android
-      - build-genie-service-windows-arm64
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write   # required for action-gh-release to create the Release
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Flatten artifacts for release
-        shell: bash
-        # actions/download-artifact@v4 lands each artifact in its own
-        # subdir. action-gh-release wants a flat file list; copy the
-        # *.whl / *.zip / *.so / GenieService dirs into a single dir.
-        run: |
-          mkdir -p release
-          # wheels and release zips from wheel jobs
-          find artifacts -type f \( -name '*.whl' -o -name 'QAI_AppBuilder-*.zip' \) -exec cp -v {} release/ \;
-          # android .so — rename to include the artifact label so it doesn't collide
-          if [ -f artifacts/libappbuilder-android-arm64v8a-qnn2.47.0.260601/libappbuilder.so ]; then
-            cp -v artifacts/libappbuilder-android-arm64v8a-qnn2.47.0.260601/libappbuilder.so \
-                  release/libappbuilder-android-arm64v8a-qnn2.47.0.260601.so
-          fi
-          # Genie c++ Service: zip the whole tree
-          genie_dir=$(find artifacts -type d -name 'GenieService-windows-arm64-*' | head -n1)
-          if [ -n "$genie_dir" ]; then
-            (cd "$genie_dir" && zip -qr "${GITHUB_WORKSPACE}/release/GenieService-windows-arm64-qnn2.47.0.260601.zip" .)
-          fi
-          echo "Release payload:"
-          ls -lh release/
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: release/*
-          generate_release_notes: true
-          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

End-to-end GitHub Actions CI pipeline that builds and tests
`qai_appbuilder` (wheels) and `GenieAPIService` (C++ binary) across all
currently supported platforms, plus four source-level bug fixes
uncovered while standing the pipeline up.

All jobs run on **GitHub-hosted runners** — no self-hosted
infrastructure required. QAIRT Community SDK is downloaded and cached
automatically.

All third-party actions used originally (`ilammy/msvc-dev-cmd`,
`nttld/setup-ndk`, `softprops/action-gh-release`) have been replaced
with inline shell equivalents to satisfy this organization's
enterprise GitHub Actions allowlist.

## What's included

### CI workflows
- `.github/workflows/ci.yml` — main pipeline
- `.github/actions/setup-qnn-sdk/action.yml` — reusable composite
  action that downloads + caches the QAIRT Community SDK and
  optionally overlays the customized Genie zip on Windows

### Build matrix

| target | runner | SDK versions | smoke test |
|---|---|---|---|
| `qai_appbuilder` wheel (win_amd64, ARM64EC) | windows-2022 | 2.46, 2.47 × py 3.11/3.12/3.13 | n/a (cross-compile) |
| `qai_appbuilder` wheel (win_arm64) | windows-11-arm | 2.46, 2.47 × py 3.11/3.12/3.13 | ✓ |
| `qai_appbuilder` wheel (linux_aarch64) | ubuntu-22.04-arm | 2.47, py 3.12 | ✓ |
| `GenieAPIService` (Windows ARM64) | windows-2022 | 2.41 → 2.47 (7 SDKs) | n/a |
| `GenieAPIService` (Linux ARM64) | ubuntu-22.04-arm | 2.47 | n/a |
| `GenieAPIService` (Android arm64-v8a) | windows-2022 | 2.47 | n/a (`continue-on-error`: APK signing keystore not configured) |

### Smoke tests (`tests/`)
- `test_package_smoke.py` — Python-level imports / public API symbols / constants
- `test_cpu_runtime_smoke.py` — pybind11 native extension + bundled `QnnCpu.dll` / `QnnSystem.dll` discovery (no NPU required)

### Source-level fixes

1. **`setup.py`** — declare `install_requires=["numpy", "pyyaml"]`.
   `qai_appbuilder/__init__.py` unconditionally imports `onnxwrapper`,
   which top-imports `numpy` and `yaml`. Without these declared,
   `pip install qai-appbuilder` followed by `import qai_appbuilder` in
   a clean venv fails with `ModuleNotFoundError`. Release-blocker for
   any downstream user.

2. **`setup.py` — `_is_wos_device()` honours `QAI_TOOLCHAINS`**. When
   CI sets `QAI_TOOLCHAINS=arm64x-windows-msvc` or `aarch64-windows-msvc`
   on a real x86_64 hosted runner, treat that as an explicit WOS
   override. Otherwise `_detect_arch()` returns `"x86_64"` and asks
   for the SDK's `x86_64-windows-msvc` toolchain subdir, which the
   Community SDK does not ship, breaking 26 GenieBuilder symbol links.

3. **`samples/python/utils/image_processing.py:205`** — add missing
   `from qai_hub_models.utils.image_processing import numpy_image_to_torch`.
   Same import pattern is already used in `samples/python/mediapipe_hand/mediapipe_hand.py`.
   Reaching the affected branch raised `NameError` before this fix;
   ruff F821 flagged it.

4. **`script/qai_appbuilder/onnxwrapper.py:681`** — construct
   `exp_shape_by_name` dict alongside sibling `exp_rank` / `exp_layout`
   dicts. The lookup referenced the variable without it being defined;
   a bare `except Exception` silently masked the `NameError` into
   `None`, so the auto-scale heuristic that detects [0,1] → [0,255]
   image inputs never received the expected shape. Models that needed
   auto-scaling silently received wrong input ranges.

5. **`samples/genie/c++/Service/src/GenieAPIService/src/model/def.h:94`**
   — drop redundant `std::` qualifier on `std::hash<ModelType>`
   specialisation. MSVC accepted `struct std::hash<X>` inside
   `namespace std { ... }`, but gcc 11 (Linux Service build) rejects
   it with `extra qualification not allowed [-fpermissive]`. Standard
   form is `struct hash<X>`.

## Test plan

- [ ] `lint` job passes
- [ ] 6 Windows x64 wheel builds pass (3 Python × 2 QNN)
- [ ] 6 Windows ARM64 wheel builds + smoke tests pass
- [ ] Linux aarch64 wheel + smoke test passes
- [ ] All 7 Windows GenieAPIService matrix rows pass (2.41 → 2.47)
- [ ] Linux Service build passes
- [ ] Android Service `.so` artifacts produced (APK assembly may fail
      until signing secrets are wired up)

## Known limitations / out of scope

- **`dependents.cmake` not touched**. Upstream `8831505` already
  improved this file substantially (Linux/Android branches, CLI11
  probe, out-of-source builds). The development branch had additional
  VS-edition-agnostic / host-arch-aware clang lookup logic, but those
  changes only matter when `USE_MNN=ON` or `USE_GGUF=ON`, which this
  PR keeps OFF. Follow-up PR can revisit if/when re-enabling those
  backends in CI.
- **Android `libappbuilder.so` job is `if: false`**. Upstream
  `make/Android.mk` now pulls `src/SVC/main.cpp` into a `QAIAppSvc`
  target, but that file is Windows-only (`<tchar.h>`, `#pragma once`
  at top of `.cpp`). Will re-enable once SVC main.cpp is made
  cross-platform.
- **`release` job removed**. Previously used `softprops/action-gh-release@v2`
  which is not on the enterprise allowlist. The job had been `if: false`
  anyway; re-introduce later with an allowed action or REST API call.
- **QNN SDK 2.40.1.251119 dropped from matrix** — its Community zip
  returns S3 NoSuchKey at apigwx-aws. Other seven SDKs unaffected.

## Development history

The full ~40-commit development branch lives at
`shijunz/ai-engine-direct-helper:ci-stage-a` and documents how each
fix was discovered. This PR branch (`ci-pr`) carries a cleaner subset:
1 squashed CI commit + 5 incremental fixes addressing build / test
failures we hit while validating on hosted runners.
