### PR TITLE
ci: add QNN Community SDK 2.48.0.260626 to build matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,16 @@ jobs:
           # qualcomm/qai-appbuilder release; setup-qnn-sdk extracts it and
           # overlays Genie.dll / Genie.lib (+ headers + libGenie.so for Linux)
           # onto the Community SDK. Leave empty to skip the overlay.
+          - version: '2.48.0.260626'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.48.0.260626/v2.48.0.260626.zip'
+            genie-url: ''
           - version: '2.47.0.260601'
             url: ''
             genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
-          # 2.46 enabled with SDK-bundled Genie only — no matching
-          # customized Genie zip is published on qualcomm/qai-appbuilder
-          # yet. Add the genie-url when that ships.
+          # Rows below use the SDK-bundled (upstream) Genie because no
+          # matching customized-Genie overlay is published on
+          # qualcomm/qai-appbuilder for that version yet. Fill in the
+          # genie-url when the overlay ships (2.48 is likely the next).
           - version: '2.46.0.260424'
             url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.46.0.260424/v2.46.0.260424.zip'
             genie-url: ''
@@ -262,6 +266,9 @@ jobs:
         python: ['3.11', '3.12', '3.13']
         qnn:
           # See windows-x64 matrix above for the genie-url convention.
+          - version: '2.48.0.260626'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.48.0.260626/v2.48.0.260626.zip'
+            genie-url: ''
           - version: '2.47.0.260601'
             url: ''
             genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
@@ -617,6 +624,9 @@ jobs:
           - version: '2.47.0.260601'
             url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.47.0.260601/v2.47.0.260601.zip'
             genie-url: 'https://github.com/qualcomm/qai-appbuilder/releases/download/v2.47.0/QAIRT_v2.47.0.260601.zip'
+          - version: '2.48.0.260626'
+            url: 'https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/2.48.0.260626/v2.48.0.260626.zip'
+            genie-url: ''
     steps:
       - name: Checkout (with genie submodules)
         uses: actions/checkout@v4


### PR DESCRIPTION
Add a 2.48.0.260626 row to the windows-x64, windows-arm64, and genie-service-windows-arm64 matrices in ci.yml. The Community SDK zip is already published at:
  https://apigwx-aws.qualcomm.com/qsc/public/v1/api/download/software/sdks/
  Qualcomm_AI_Runtime_Community/All/2.48.0.260626/v2.48.0.260626.zip

Verified locally:
  - Download URL returns HTTP 206 / application/x-zip-compressed
  - Zip layout is `qairt/2.48.0.260626/...` matching the setup-qnn-sdk composite action's third probe candidate.
  - lib/ contains the same 20 subdirs as 2.47.0.260601, including arm64x-windows-msvc, aarch64-windows-msvc, aarch64-ubuntu-gcc9.4, hexagon-v81, and lpai-v5/v5_1/v6.
  - All setup.py-consumed artifacts are present: lib/arm64x-windows-msvc/{QnnHtp,QnnSystem,QnnCpu,Genie}.dll lib/arm64x-windows-msvc/Genie.lib lib/aarch64-windows-msvc/{QnnHtp,QnnSystem,Genie}.dll lib/aarch64-ubuntu-gcc9.4/{libQnnHtp,libQnnSystem}.so lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so include/QNN/QnnCommon.h, include/Genie/GenieDialog.h

The customized-Genie overlay zip is not yet published on qualcomm/qai-appbuilder for v2.48 (only v2.47.0 has one), so the new row leaves `genie-url` empty — the build will use the SDK-bundled Genie, matching the treatment of the 2.46 row. When the overlay ships, populate genie-url on the 2.48 row the same way as 2.47.

The four single-version pipelines (linux-aarch64 wheel, android libappbuilder, and both genie-c++-linux/android jobs) remain pinned to 2.47.0.260601 for now. They will move to 2.48 in a follow-up once the matrix jobs on this PR validate the new SDK end-to-end.