### PR TITLE
feat(async): async model load and parallel inference for cross-process mode

### DIFF
--- a/pybind/AppBuilder.cpp
+++ b/pybind/AppBuilder.cpp
@@ -130,9 +130,95 @@ QNNContext::Inference(const std::vector<py::array>& input, const std::string& pe
     return inference(m_model_name, input, perf_profile, graphIndex, input_data_type, output_data_type);
 }
 
-std::vector<py::array> 
+std::vector<py::array>
 QNNContext::Inference(const ShareMemory& share_memory, const std::vector<py::array>& input, const std::string& perf_profile, size_t graphIndex, const std::string& input_data_type, const std::string& output_data_type) {
     return inference_P(m_model_name, m_proc_name, share_memory.m_share_memory_name, input, perf_profile, graphIndex, input_data_type, output_data_type);
+}
+
+std::string
+QNNContext::InferenceAsync(const ShareMemory& share_memory, const std::vector<py::array>& input,
+                           const std::string& perf_profile, size_t graphIndex,
+                           const std::string& input_data_type, const std::string& output_data_type) {
+    std::vector<uint8_t*> inputBuffers;
+    std::vector<size_t>   inputSize;
+    std::vector<py::array> keepAlive;
+    const bool floatMode = isFloat32Request(input_data_type);
+
+    for (auto i = 0; i < (int)input.size(); i++) {
+        if (floatMode) {
+            py::array_t<float, py::array::c_style | py::array::forcecast> farr(input[i]);
+            py::buffer_info buf = farr.request();
+            keepAlive.push_back(py::array(farr));
+            inputBuffers.push_back(reinterpret_cast<uint8_t*>(buf.ptr));
+            inputSize.push_back(static_cast<size_t>(buf.size) * static_cast<size_t>(buf.itemsize));
+        } else {
+            py::array carr = py::array::ensure(input[i], py::array::c_style);
+            if (!carr) throw std::runtime_error("Failed to ensure contiguous input array");
+            py::buffer_info buf = carr.request();
+            keepAlive.push_back(carr);
+            inputBuffers.push_back(reinterpret_cast<uint8_t*>(buf.ptr));
+            inputSize.push_back(static_cast<size_t>(buf.size) * static_cast<size_t>(buf.itemsize));
+        }
+    }
+
+    std::string perf = perf_profile;
+    return g_LibAppBuilder.ModelInferenceAsync(
+        m_model_name, m_proc_name, share_memory.m_share_memory_name,
+        inputBuffers, inputSize, perf, graphIndex);
+}
+
+std::vector<py::array>
+QNNContext::InferenceWait(const std::string& request_id, const ShareMemory& share_memory,
+                          const std::string& output_data_type) {
+    std::vector<uint8_t*> outputBuffers;
+    std::vector<size_t>   outputSize;
+
+    bool success = g_LibAppBuilder.ModelWaitInference(
+        request_id, m_proc_name, share_memory.m_share_memory_name,
+        outputBuffers, outputSize);
+
+    if (!success) {
+        QNN_ERR("InferenceWait failed for request_id: %s\n", request_id.c_str());
+        return {};
+    }
+
+    const bool floatOutMode = isFloat32Request(output_data_type);
+    std::vector<std::string> outDtypes  = g_LibAppBuilder.getOutputDataType(m_model_name, m_proc_name);
+    std::vector<std::vector<size_t>> outShapes = g_LibAppBuilder.getOutputShapes(m_model_name, m_proc_name);
+
+    std::vector<py::array> output;
+    for (size_t i = 0; i < outputBuffers.size(); i++) {
+        std::string dtypeStr = (i < outDtypes.size()) ? outDtypes[i] : std::string("uint8");
+        const std::vector<size_t> shape = (i < outShapes.size()) ? outShapes[i] : std::vector<size_t>{};
+        py::dtype dt = inferOutputNumpyDtype((i < outputSize.size()) ? outputSize[i] : 0, shape, dtypeStr);
+
+        size_t elemCount = 0;
+        if (!shape.empty()) {
+            elemCount = productDims(shape);
+        } else {
+            const size_t itemBytes = static_cast<size_t>(dt.itemsize());
+            if (itemBytes > 0 && i < outputSize.size() && (outputSize[i] % itemBytes) == 0)
+                elemCount = outputSize[i] / itemBytes;
+            else if (i < outputSize.size()) {
+                dt = py::dtype::of<uint8_t>();
+                elemCount = outputSize[i];
+            }
+        }
+
+        py::capsule free_data(outputBuffers[i], [](void* f) {});  // shared memory — don't free
+        py::array result(dt,
+                        { static_cast<py::ssize_t>(elemCount) },
+                        { static_cast<py::ssize_t>(dt.itemsize()) },
+                        outputBuffers[i], free_data);
+
+        if (floatOutMode && !isNumpyFloat32Dtype(dt)) {
+            py::array_t<float, py::array::c_style | py::array::forcecast> farr(result);
+            output.push_back(py::array(farr));
+        } else {
+            output.push_back(result);
+        }
+    }
+    return output;
 }
 
 bool QNNContext::ApplyBinaryUpdate(const std::vector<LoraAdapter>& lora_adapters) {
@@ -164,26 +250,13 @@ PYBIND11_MODULE(appbuilder, m) {
     m.attr("__license__") = "BSD-3-Clause";
 
     m.def("model_initialize", &initialize, "Initialize models.");
-
-#ifdef _WIN32
     m.def("model_initialize", &initialize_P, "Initialize models.");
-#endif
 
     m.def("model_inference", &inference, "Inference models.");
-
-#ifdef _WIN32
     m.def("model_inference", &inference_P, "Inference models.");
-#endif
 
-#ifdef _WIN32
-    m.def("model_destroy", &destroy, "Destroy models.");
-#else
     m.def("model_destroy", static_cast<int(*)(std::string)>(&destroy), "Destroy models.");
-#endif
-
-#ifdef _WIN32
     m.def("model_destroy", &destroy_P, "Destroy models.");
-#endif
 
     m.def("memory_create", &create_memory, "Create share memory.");
     m.def("memory_delete", &delete_memory, "Delete share memory.");
@@ -202,6 +275,13 @@ PYBIND11_MODULE(appbuilder, m) {
         .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, bool, const std::string&, const std::string&, uint32_t, std::string>())
         .def("Inference", py::overload_cast<const std::vector<py::array>&, const std::string&, size_t, const std::string&, const std::string&>(&QNNContext::Inference))
         .def("Inference", py::overload_cast<const ShareMemory&, const std::vector<py::array>&, const std::string&, size_t, const std::string&, const std::string&>(&QNNContext::Inference))
+        .def("InferenceAsync", &QNNContext::InferenceAsync,
+             py::arg("share_memory"), py::arg("input"),
+             py::arg("perf_profile") = "default", py::arg("graphIndex") = 0,
+             py::arg("input_data_type") = "float", py::arg("output_data_type") = "float")
+        .def("InferenceWait", &QNNContext::InferenceWait,
+             py::arg("request_id"), py::arg("share_memory"),
+             py::arg("output_data_type") = "float")
         .def("ApplyBinaryUpdate", &QNNContext::ApplyBinaryUpdate, "Apply Lora binary update")
         .def("getInputShapes", py::overload_cast<>(&QNNContext::getInputShapes)) 
         .def("getInputDataType", py::overload_cast<>(&QNNContext::getInputDataType)) 

--- a/pybind/AppBuilder.h
+++ b/pybind/AppBuilder.h
@@ -446,6 +446,12 @@ public:
     std::vector<py::array> Inference(const std::vector<py::array>& input, const std::string& perf_profile = "default", size_t graphIndex = 0, const std::string& input_data_type="float", const std::string& output_data_type="float");
     std::vector<py::array> Inference(const ShareMemory& share_memory, const std::vector<py::array>& input, const std::string& perf_profile = "default", size_t graphIndex = 0, const std::string& input_data_type="float", const std::string& output_data_type="float");
 
+    // Async cross-process inference: returns a request_id string immediately.
+    std::string InferenceAsync(const ShareMemory& share_memory, const std::vector<py::array>& input, const std::string& perf_profile = "default", size_t graphIndex = 0, const std::string& input_data_type="float", const std::string& output_data_type="float");
+
+    // Wait for an async inference started by InferenceAsync() and return outputs.
+    std::vector<py::array> InferenceWait(const std::string& request_id, const ShareMemory& share_memory, const std::string& output_data_type="float");
+
     bool ApplyBinaryUpdate(const std::vector<LoraAdapter>& lora_adapters);
 
     // issue#24

--- a/pybind/common.h
+++ b/pybind/common.h
@@ -11,7 +11,7 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 
-#define APPBUILDER_VERSION "2.47.0"
+#define APPBUILDER_VERSION "2.47.1"
 
 #endif
 

--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -857,13 +857,32 @@ class QNNContextProc(_QNNContextBase):
         total_input_bytes = sum(arr.nbytes for arr in input)
         if total_input_bytes > shareMemory.share_memory_size:
             raise ValueError(f"Input data size {total_input_bytes} exceeds share memory size {shareMemory.share_memory_size}, you need to create a larger share memory for model {self.model_name} @ process {self.proc_name}.")
-            # print(f"Input data size {total_input_bytes} exceeds share memory size {shareMemory.share_memory_size}, you need to create a larger share memory for model {self.model_name} @ process {self.proc_name}.")
 
         return self._inference_and_reshape(
             input,
             lambda _in: self.m_context.Inference(shareMemory.m_memory, _in, perf_profile, graphIndex,
                                                  self.input_data_type, self.output_data_type)
         )
+
+    def InferenceAsync(self, shareMemory, input, perf_profile=PerfProfile.DEFAULT, graphIndex=0):
+        """Launch inference asynchronously on the Svc side.
+        Returns a request_id string; the Svc main loop remains unblocked.
+        Call InferenceWait(request_id, shareMemory) to collect the outputs."""
+        self._ensure_live("InferenceAsync")
+        total_input_bytes = sum(arr.nbytes for arr in input)
+        if total_input_bytes > shareMemory.share_memory_size:
+            raise ValueError(f"Input data size {total_input_bytes} exceeds share memory size.")
+        reshaped = reshape_input(list(input))
+        return self.m_context.InferenceAsync(shareMemory.m_memory, reshaped, perf_profile, graphIndex,
+                                             self.input_data_type, self.output_data_type)
+
+    def InferenceWait(self, request_id, shareMemory):
+        """Wait for the async inference identified by request_id and return
+        the reshaped output arrays."""
+        self._ensure_live("InferenceWait")
+        output = self.m_context.InferenceWait(request_id, shareMemory.m_memory, self.output_data_type)
+        outputshape_list = self.getOutputShapes()
+        return reshape_output(output, outputshape_list)
 
 
 class QNNLoraContext(_QNNContextBase):

--- a/setup.py
+++ b/setup.py
@@ -961,7 +961,7 @@ setup(
         # qai_appbuilder/__init__.py unconditionally imports onnxwrapper,
         # whose top-level imports require numpy + pyyaml. Without these,
         # `pip install qai-appbuilder` in a clean venv fails to import.
-        "numpy",
+        "numpy>=1.22,<=2.4.4",
         "pyyaml",
     ],
     classifiers=[

--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -755,11 +755,37 @@ bool LibAppBuilder::ModelInference(std::string model_name, std::string proc_name
     return false;
 }
 
-bool LibAppBuilder::ModelInference(std::string model_name, std::vector<uint8_t*>& inputBuffers, 
+bool LibAppBuilder::ModelInference(std::string model_name, std::vector<uint8_t*>& inputBuffers,
                                    std::vector<uint8_t*>& outputBuffers, std::vector<size_t>& outputSize,
                                    std::string& perfProfile, size_t graphIndex, size_t share_memory_size){
     std::vector<size_t> inputSize;
     return ModelInferenceEx(model_name, "", "", inputBuffers, inputSize, outputBuffers, outputSize, perfProfile, graphIndex, share_memory_size);
+}
+
+std::string LibAppBuilder::ModelInferenceAsync(std::string model_name, std::string proc_name,
+                                               std::string share_memory_name,
+                                               std::vector<uint8_t*>& inputBuffers,
+                                               std::vector<size_t>& inputSize,
+                                               std::string& perfProfile, size_t graphIndex) {
+    if (proc_name.empty()) {
+        QNN_ERR("ModelInferenceAsync: proc_name is required.\n");
+        return "";
+    }
+    return TalkToSvc_InferenceAsync(model_name, proc_name, share_memory_name,
+                                    inputBuffers, inputSize, perfProfile, graphIndex);
+}
+
+bool LibAppBuilder::ModelWaitInference(const std::string& request_id,
+                                       const std::string& proc_name,
+                                       const std::string& share_memory_name,
+                                       std::vector<uint8_t*>& outputBuffers,
+                                       std::vector<size_t>& outputSize) {
+    if (proc_name.empty()) {
+        QNN_ERR("ModelWaitInference: proc_name is required.\n");
+        return false;
+    }
+    return TalkToSvc_WaitInference(request_id, proc_name, share_memory_name,
+                                   outputBuffers, outputSize);
 }
 
 bool LibAppBuilder::ModelApplyBinaryUpdate(const std::string model_name, std::vector<LoraAdapter>& lora_adapters) {

--- a/src/LibAppBuilder.hpp
+++ b/src/LibAppBuilder.hpp
@@ -74,6 +74,20 @@ public:
                         std::vector<uint8_t*>& outputBuffers, std::vector<size_t>& outputSize,
                         std::string& perfProfile, size_t graphIndex = 0);
 
+    // Async cross-process inference: send inputs and return immediately with a
+    // request_id.  Call ModelWaitInference() later to collect the outputs.
+    std::string ModelInferenceAsync(std::string model_name, std::string proc_name,
+                                    std::string share_memory_name,
+                                    std::vector<uint8_t*>& inputBuffers,
+                                    std::vector<size_t>& inputSize,
+                                    std::string& perfProfile, size_t graphIndex = 0);
+
+    bool ModelWaitInference(const std::string& request_id,
+                            const std::string& proc_name,
+                            const std::string& share_memory_name,
+                            std::vector<uint8_t*>& outputBuffers,
+                            std::vector<size_t>& outputSize);
+
     bool ModelApplyBinaryUpdate(const std::string model_name, std::vector<LoraAdapter>& lora_adapters);
 
     bool ModelDestroy(std::string model_name);

--- a/src/SVC/Utils/Utils.hpp
+++ b/src/SVC/Utils/Utils.hpp
@@ -319,11 +319,13 @@ std::pair<std::string, std::string> VectorToShareMem(size_t share_memory_size, u
     uint8_t* buffer = nullptr;
 
     // How to handle the case - part of the data in buffers are in the share memory?
-    // Calculate the offset, avoid overflow the input data which already in the share memory.
-    for (int i = 0; i < buffers.size(); i++) {
+    // Calculate the offset for out-of-shm copies: must start AFTER the last byte
+    // of any buffer that already lives in shm, so we don't overwrite it.
+    for (int i = 0; i < (int)buffers.size(); i++) {
         buffer = buffers[i];
-        if (buffer >= lpBase && buffer <= lpBase + share_memory_size) {     // This buffer is in the share memory area.
-            offset += size[i];
+        if (buffer >= lpBase && buffer < lpBase + share_memory_size) {     // This buffer is in the share memory area.
+            size_t end = (size_t)(buffer - lpBase) + size[i];
+            if (end > offset) offset = end;
         }
     }
 
@@ -331,7 +333,7 @@ std::pair<std::string, std::string> VectorToShareMem(size_t share_memory_size, u
     for (int i = 0; i < buffers.size(); i++) {
         buffer = buffers[i];
         dataSize = size[i];
-        if (buffer >= lpBase && buffer <= lpBase + share_memory_size) {     // This buffer is in the share memory area.
+        if (buffer >= lpBase && buffer < lpBase + share_memory_size) {     // This buffer is in the share memory area.
             strOffsetArray += std::to_string(buffer - lpBase) + ",";
             //QNN_INF("VectorToShareMem in buffers, ignore copy.\n");
         }
@@ -469,6 +471,97 @@ BOOL TalkToSvc_Inference(std::string model_name, std::string proc_name, std::str
     }
 
     return bSuccess;
+}
+
+// Launch inference asynchronously on the Svc side.
+// Returns a request_id string; the caller must later call TalkToSvc_WaitInference
+// with that id to retrieve the result.
+std::string TalkToSvc_InferenceAsync(std::string model_name, std::string proc_name,
+                                     std::string share_memory_name,
+                                     std::vector<uint8_t*>& inputBuffers,
+                                     std::vector<size_t>& inputSize,
+                                     std::string perfProfile, size_t graphIndex) {
+    ProcInfo_t* pProcInfo = FindProcInfo(proc_name);
+    if (!pProcInfo) {
+        QNN_ERR("TalkToSvc_InferenceAsync::Cant find this process %s.\n", proc_name.c_str());
+        return "";
+    }
+
+    ShareMemInfo_t* pShareMemInfo = FindShareMem(share_memory_name);
+    if (!pShareMemInfo) {
+        QNN_ERR("TalkToSvc_InferenceAsync::Cant find this share memory %s.\n", share_memory_name.c_str());
+        return "";
+    }
+
+    ipc::IpcChannel* channel = pProcInfo->channel.get();
+    size_t dwRead = 0;
+    bool bSuccess;
+
+    std::string command = "g" + model_name + ";" + share_memory_name + ";" +
+                          std::to_string(pShareMemInfo->size) + ";";
+    std::pair<std::string, std::string> strResultArray =
+        VectorToShareMem(pShareMemInfo->size, (uint8_t*)pShareMemInfo->lpBase, inputBuffers, inputSize);
+    command = command + strResultArray.first + "=" + strResultArray.second + ";";
+    command = command + perfProfile + ";";
+    command = command + std::to_string(graphIndex) + ";async";   // mark as async
+
+    ipc::ShmHandle shmHandle = pShareMemInfo->region ? pShareMemInfo->region->Handle() : ipc::kInvalidShm();
+    bSuccess = channel->WriteWithFd(command.c_str(), command.length() + 1, shmHandle);
+    if (!bSuccess) return "";
+
+    // Server replies with request_id immediately (not the full result).
+    bSuccess = channel->Read(g_buffer, GLOBAL_BUFSIZE, dwRead);
+    if (!bSuccess || dwRead == 0) {
+        QNN_ERR("TalkToSvc_InferenceAsync::Failed to read request_id.\n");
+        return "";
+    }
+    g_buffer[dwRead] = 0;
+    if (g_buffer[0] == 'F') return "";
+
+    return std::string(g_buffer);
+}
+
+// Block until a previously launched async inference (request_id) is complete
+// and collect the output buffers from shared memory.
+BOOL TalkToSvc_WaitInference(const std::string& request_id,
+                              const std::string& proc_name,
+                              const std::string& share_memory_name,
+                              std::vector<uint8_t*>& outputBuffers,
+                              std::vector<size_t>& outputSize) {
+    if (request_id.empty()) return false;
+
+    ProcInfo_t* pProcInfo = FindProcInfo(proc_name);
+    if (!pProcInfo) {
+        QNN_ERR("TalkToSvc_WaitInference::Cant find this process %s.\n", proc_name.c_str());
+        return false;
+    }
+
+    ShareMemInfo_t* pShareMemInfo = FindShareMem(share_memory_name);
+    if (!pShareMemInfo) {
+        QNN_ERR("TalkToSvc_WaitInference::Cant find this share memory %s.\n", share_memory_name.c_str());
+        return false;
+    }
+
+    ipc::IpcChannel* channel = pProcInfo->channel.get();
+    size_t dwRead = 0;
+    bool bSuccess;
+
+    std::string command = "q" + request_id;
+    bSuccess = channel->Write(command.c_str(), command.length() + 1);
+    if (!bSuccess) return false;
+
+    bSuccess = channel->Read(g_buffer, GLOBAL_BUFSIZE, dwRead);
+    if (dwRead) {
+        g_buffer[dwRead] = 0;
+        QNN_INF("TalkToSvc_WaitInference::ReadFromPipe: %s dwRead = %d\n", g_buffer, (int)dwRead);
+    } else {
+        QNN_ERR("TalkToSvc_WaitInference::ReadFromPipe: Failed, perhaps child process died.\n");
+    }
+    if (!bSuccess || dwRead == 0) return false;
+    if (g_buffer[0] == 'F') return false;
+
+    ShareMemToVector(g_buffer, (uint8_t*)pShareMemInfo->lpBase, outputBuffers, outputSize);
+    return true;
 }
 
 std::vector<std::string> split(const std::string& s, char delim) {

--- a/src/SVC/main.cpp
+++ b/src/SVC/main.cpp
@@ -11,6 +11,10 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <future>
+#include <mutex>
+#include <unordered_map>
+#include <atomic>
 
 
 // ============================== Service / QAIAppSvc ============================== //
@@ -20,13 +24,35 @@
 
 LibAppBuilder g_LibAppBuilder;
 
+// Tracks pending async model loads: model_name -> future<bool>
+static std::mutex g_async_futures_mutex;
+static std::unordered_map<std::string, std::future<bool>> g_async_futures;
+
+// Async inference result storage
+struct InferResult {
+    bool        success = false;
+    std::string offsets;   // strOffsetArray
+    std::string sizes;     // strSizeArray
+};
+
+static std::atomic<uint64_t> g_request_counter{0};
+static std::mutex g_infer_results_mutex;
+static std::unordered_map<std::string, std::future<InferResult>> g_infer_futures;
+
 // Server side: map the shared-memory region for this inference.
 //   Windows : open the named mapping created by the client.
 //   POSIX   : adopt the fd just received over the command channel (SCM_RIGHTS).
-void* OpenShareMem(std::string share_memory_name, size_t share_memory_size, ipc::ShmHandle posixFd = ipc::kInvalidShm()) {
+// registry_key: the key used in sg_share_mem_map (defaults to share_memory_name).
+//   For async inferences, pass a unique key to avoid aliasing when the same
+//   share_memory_name is used concurrently by multiple background threads.
+void* OpenShareMem(std::string share_memory_name, size_t share_memory_size,
+                   ipc::ShmHandle posixFd = ipc::kInvalidShm(),
+                   const std::string& registry_key = "") {
+    const std::string& reg_key = registry_key.empty() ? share_memory_name : registry_key;
     std::unique_ptr<ipc::SharedRegion> region;
 #ifdef _WIN32
     (void)posixFd;
+    // Windows: OS-level name stays share_memory_name; only the map key differs.
     region = ipc::SharedRegion::OpenByName(share_memory_name, share_memory_size);
 #else
     region = ipc::SharedRegion::OpenFromHandle(posixFd, share_memory_size);
@@ -36,7 +62,7 @@ void* OpenShareMem(std::string share_memory_name, size_t share_memory_size, ipc:
     }
 
     void* lpBase = region->Base();
-    if (!RegisterShareMem(share_memory_name, std::move(region))) {
+    if (!RegisterShareMem(reg_key, std::move(region))) {
         return nullptr;
     }
     return lpBase;
@@ -53,7 +79,6 @@ void CloseShareMem(std::string share_memory_name) {
 }
 
 void ModelLoad(std::string cmdBuf, ipc::IpcChannel* channel) {
-    BOOL bSuccess;
     Print_MemInfo("ModelLoad Start.");
 
     std::vector<std::string> commands;
@@ -67,27 +92,77 @@ void ModelLoad(std::string cmdBuf, ipc::IpcChannel* channel) {
     std::string input_data_type             = commands[5];
     std::string output_data_type            = commands[6];
 
-    Print_MemInfo("ModelLoad::ModelInitialize Start.");
-    QNN_INF("ModelLoad::ModelInitialize::Model name %s\n", model_name.c_str());
-    std::vector<LoraAdapter> Adapters ;
-    bSuccess = g_LibAppBuilder.ModelInitialize(model_name.c_str(), model_path, backend_lib_path, system_lib_path, Adapters, false, input_data_type, output_data_type);
-    QNN_INF("ModelLoad::ModelInitialize End ret = %d\n", bSuccess);
-    Print_MemInfo("ModelLoad::ModelInitialize End.");
+    bool async = (async_str == "async");
 
-    if (!(async_str == "async")) {  // We only notify client when sync mode. TODO: Async mode will notify client by callback function.
-        if(bSuccess) {
-            channel->Write(ACTION_OK, strlen(ACTION_OK) + 1);
+    if (async) {
+        // Launch model initialization on a background thread.
+        // ModelRun will wait for it to finish before running inference.
+        std::vector<LoraAdapter> Adapters;
+        std::future<bool> fut = std::async(std::launch::async, [=]() mutable -> bool {
+            Print_MemInfo("ModelLoad(async)::ModelInitialize Start.");
+            QNN_INF("ModelLoad(async)::ModelInitialize::Model name %s\n", model_name.c_str());
+            bool bSuccess = g_LibAppBuilder.ModelInitialize(model_name.c_str(), model_path, backend_lib_path, system_lib_path, Adapters, false, input_data_type, output_data_type);
+            QNN_INF("ModelLoad(async)::ModelInitialize End ret = %d\n", bSuccess);
+            Print_MemInfo("ModelLoad(async)::ModelInitialize End.");
+            return bSuccess;
+        });
+
+        {
+            std::lock_guard<std::mutex> lk(g_async_futures_mutex);
+            g_async_futures[model_name] = std::move(fut);
         }
-        else {
+        // Do not send a response — client does not wait in async mode.
+    } else {
+        Print_MemInfo("ModelLoad::ModelInitialize Start.");
+        QNN_INF("ModelLoad::ModelInitialize::Model name %s\n", model_name.c_str());
+        std::vector<LoraAdapter> Adapters;
+        BOOL bSuccess = g_LibAppBuilder.ModelInitialize(model_name.c_str(), model_path, backend_lib_path, system_lib_path, Adapters, false, input_data_type, output_data_type);
+        QNN_INF("ModelLoad::ModelInitialize End ret = %d\n", bSuccess);
+        Print_MemInfo("ModelLoad::ModelInitialize End.");
+
+        if (bSuccess) {
+            channel->Write(ACTION_OK, strlen(ACTION_OK) + 1);
+        } else {
             channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
         }
     }
 }
 
+// If there is a pending async load for this model, wait for it to finish.
+// Returns false if the load failed; true if load succeeded or was already done.
+static bool WaitForAsyncLoad(const std::string& model_name) {
+    std::future<bool> fut;
+    {
+        std::lock_guard<std::mutex> lk(g_async_futures_mutex);
+        auto it = g_async_futures.find(model_name);
+        if (it != g_async_futures.end()) {
+            fut = std::move(it->second);
+            g_async_futures.erase(it);
+        }
+    }
+    if (fut.valid()) {
+        return fut.get();
+    }
+    return true;  // no pending async load — nothing to wait for
+}
+
+// Wait for all pending async model loads to finish (used by perf commands that
+// require the backend handle to be initialized).
+static void WaitForAllAsyncLoads() {
+    std::unordered_map<std::string, std::future<bool>> pending;
+    {
+        std::lock_guard<std::mutex> lk(g_async_futures_mutex);
+        pending = std::move(g_async_futures);
+    }
+    for (auto& kv : pending) {
+        if (kv.second.valid()) {
+            kv.second.get();
+        }
+    }
+}
+
 void ModelRun(std::string cmdBuf, ipc::IpcChannel* channel, ipc::ShmHandle posixFd) {
-    BOOL bSuccess;
     Print_MemInfo("ModelRun Start.");
-    // TimerHelper timerHelper;
 
     std::vector<std::string> commands;
     split_string(commands, cmdBuf, ';');
@@ -98,43 +173,129 @@ void ModelRun(std::string cmdBuf, ipc::IpcChannel* channel, ipc::ShmHandle posix
     std::string strBufferArray    = commands[3];
     std::string perfProfile       = commands[4];
     size_t graphIndex             = std::stoull(commands[5]);
+    // commands[6]: "async" or "sync" (optional, default sync)
+    bool async_infer = (commands.size() > 6 && commands[6] == "async");
 
-    // Open share memory and read the inference data from share memory.
-    // On POSIX 'posixFd' is the fd received with this command via SCM_RIGHTS.
-    void* lpBase = OpenShareMem(share_memory_name, share_memory_size, posixFd);
-
-    std::vector<uint8_t*> inputBuffers;
-    std::vector<size_t> inputSize;
-    std::vector<uint8_t*> outputBuffers;
-    std::vector<size_t> outputSize;
-    outputSize.push_back(12345);    // Indicte that this is a share memory output.
-
-    // Fill data from 'pShareMemInfo->lpBase' to 'inputBuffers' vector before inference the model.
-    ShareMemToVector(strBufferArray, (uint8_t*)lpBase, inputBuffers, inputSize);
-
-    Print_MemInfo("ModelRun::ModelInference Start.");
-    //QNN_INF("ModelRun::ModelInference %s\n", model_name.c_str());
-    bSuccess = g_LibAppBuilder.ModelInference(model_name.c_str(), inputBuffers, outputBuffers, outputSize, perfProfile, graphIndex, share_memory_size);
-    //QNN_INF("ModelRun::ModelInference End ret = %d\n", bSuccess);
-    Print_MemInfo("ModelRun::ModelInference End.");
-
-    // Fill data from outputBuffers to 'pShareMemInfo->lpBase' and send back to client.
-    std::pair<std::string, std::string> strResultArray = VectorToShareMem(share_memory_size, (uint8_t*)lpBase, outputBuffers, outputSize);
-
-    outputBuffers.clear();
-    outputSize.clear();
-
-    Print_MemInfo("ModelRun::CloseShareMem Start.");
-    CloseShareMem(share_memory_name);
-    Print_MemInfo("ModelRun::CloseShareMem End.");
-
-    // timerHelper.Print("ModelRun");
-
-    std::string command = strResultArray.first + "=" + strResultArray.second;
-    if (bSuccess) {
-        channel->Write(command.c_str(), command.length() + 1);
+    // If the model was loaded asynchronously, wait for it to finish before inference.
+    if (!WaitForAsyncLoad(model_name)) {
+        QNN_ERR("ModelRun: async model load failed for '%s'\n", model_name.c_str());
+        channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
+        return;
     }
-    else {
+
+    if (async_infer) {
+        // Generate a unique request_id and reply immediately.
+        uint64_t req_id = ++g_request_counter;
+        std::string request_id = model_name + "_req_" + std::to_string(req_id);
+
+        // Use a unique SHM registration key per request to avoid aliasing when
+        // two async inferences for the same model run concurrently.
+        std::string shm_key = share_memory_name + "_" + request_id;
+
+        // On POSIX the fd must survive until the lambda finishes; dup it so the
+        // server's main loop closing posixFd doesn't affect the lambda.
+#ifndef _WIN32
+        ipc::ShmHandle lambdaFd = (posixFd >= 0) ? ::dup(posixFd) : posixFd;
+#else
+        ipc::ShmHandle lambdaFd = posixFd;
+#endif
+
+        std::future<InferResult> fut = std::async(std::launch::async,
+            [=]() mutable -> InferResult {
+                InferResult result;
+
+                void* lpBase = OpenShareMem(share_memory_name, share_memory_size, lambdaFd, shm_key);
+                if (!lpBase) {
+#ifndef _WIN32
+                    if (lambdaFd >= 0) ::close(lambdaFd);
+#endif
+                    return result;
+                }
+
+                std::vector<uint8_t*> inputBuffers, outputBuffers;
+                std::vector<size_t>   inputSize, outputSize;
+                // outputSize must start empty — ModelInference populates it.
+                ShareMemToVector(strBufferArray, (uint8_t*)lpBase, inputBuffers, inputSize);
+
+                result.success = g_LibAppBuilder.ModelInference(
+                    model_name.c_str(), inputBuffers, outputBuffers, outputSize,
+                    perfProfile, graphIndex, share_memory_size);
+
+                if (result.success) {
+                    auto strResultArray = VectorToShareMem(
+                        share_memory_size, (uint8_t*)lpBase, outputBuffers, outputSize);
+                    result.offsets = strResultArray.first;
+                    result.sizes   = strResultArray.second;
+                }
+                outputBuffers.clear();
+                outputSize.clear();
+                CloseShareMem(shm_key);
+                return result;
+            });
+
+        {
+            std::lock_guard<std::mutex> lk(g_infer_results_mutex);
+            g_infer_futures[request_id] = std::move(fut);
+        }
+        // Send request_id back immediately so client can do other work.
+        channel->Write(request_id.c_str(), request_id.length() + 1);
+    } else {
+        // Synchronous path (original behaviour).
+        void* lpBase = OpenShareMem(share_memory_name, share_memory_size, posixFd);
+
+        std::vector<uint8_t*> inputBuffers, outputBuffers;
+        std::vector<size_t>   inputSize, outputSize;
+        // outputSize must start empty — ModelInference populates it.
+        ShareMemToVector(strBufferArray, (uint8_t*)lpBase, inputBuffers, inputSize);
+
+        Print_MemInfo("ModelRun::ModelInference Start.");
+        BOOL bSuccess = g_LibAppBuilder.ModelInference(
+            model_name.c_str(), inputBuffers, outputBuffers, outputSize,
+            perfProfile, graphIndex, share_memory_size);
+        Print_MemInfo("ModelRun::ModelInference End.");
+
+        std::pair<std::string, std::string> strResultArray =
+            VectorToShareMem(share_memory_size, (uint8_t*)lpBase, outputBuffers, outputSize);
+
+        outputBuffers.clear();
+        outputSize.clear();
+        CloseShareMem(share_memory_name);
+
+        std::string command = strResultArray.first + "=" + strResultArray.second;
+        if (bSuccess) {
+            channel->Write(command.c_str(), command.length() + 1);
+        } else {
+            channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
+        }
+    }
+}
+
+// Client sends 'q' + request_id to collect the result of an async inference.
+void ModelQueryResult(std::string cmdBuf, ipc::IpcChannel* channel) {
+    std::string request_id = cmdBuf;   // everything after 'q'
+
+    std::future<InferResult> fut;
+    {
+        std::lock_guard<std::mutex> lk(g_infer_results_mutex);
+        auto it = g_infer_futures.find(request_id);
+        if (it != g_infer_futures.end()) {
+            fut = std::move(it->second);
+            g_infer_futures.erase(it);
+        }
+    }
+
+    if (!fut.valid()) {
+        QNN_ERR("ModelQueryResult: unknown request_id '%s'\n", request_id.c_str());
+        channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
+        return;
+    }
+
+    InferResult result = fut.get();   // blocks until background inference finishes
+
+    if (result.success) {
+        std::string command = result.offsets + "=" + result.sizes;
+        channel->Write(command.c_str(), command.length() + 1);
+    } else {
         channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
     }
 }
@@ -147,6 +308,12 @@ void ModelRelease(std::string cmdBuf, ipc::IpcChannel* channel) {
     split_string(commands, cmdBuf, ';');
 
     std::string model_name = commands[0];
+
+    // Ensure any pending async load finishes before destroying the model.
+    if (!WaitForAsyncLoad(model_name)) {
+        QNN_ERR("ModelRelease: async model load failed for '%s', proceeding with destroy\n", model_name.c_str());
+        // Continue with destroy even if load failed, to clean up resources.
+    }
 
     Print_MemInfo("ModelRelease::ModelDestroy Start.");
     QNN_INF("ModelRelease::ModelDestroy %s\n", model_name.c_str());
@@ -166,6 +333,7 @@ void ModelRelease(std::string cmdBuf, ipc::IpcChannel* channel) {
 // (and thus the QNN backend handle) actually lives. Called for the 'p' / 'e'
 // commands forwarded by the client's PerfProfile.SetPerfProfileGlobal / Rel.
 void SetPerf(std::string cmdBuf, ipc::IpcChannel* channel) {
+    WaitForAllAsyncLoads();   // backend handle must exist before applying perf profile
     std::string perf_profile = cmdBuf;   // remainder after the 'p' command byte
     BOOL bSuccess = SetPerfProfileGlobal(perf_profile);
     if (bSuccess) {
@@ -177,6 +345,7 @@ void SetPerf(std::string cmdBuf, ipc::IpcChannel* channel) {
 }
 
 void RelPerf(ipc::IpcChannel* channel) {
+    WaitForAllAsyncLoads();   // backend handle must exist before releasing perf profile
     BOOL bSuccess = RelPerfProfileGlobal();
     if (bSuccess) {
         channel->Write(ACTION_OK, strlen(ACTION_OK) + 1);
@@ -213,6 +382,13 @@ void getModelInfo(std::string cmdBuf, ipc::IpcChannel* channel) {
     split_string(commands, cmdBuf, ';');
     std::string model_name   = commands[0];
     std::string input        = commands[1];
+
+    // Ensure any pending async load finishes before querying model info.
+    if (!WaitForAsyncLoad(model_name)) {
+        QNN_ERR("getModelInfo: async model load failed for '%s'\n", model_name.c_str());
+        channel->Write(ACTION_FAILED, strlen(ACTION_FAILED) + 1);
+        return;
+    }
 
     ModelInfo_t output = g_LibAppBuilder.getModelInfo(model_name, input);
     std::string command;
@@ -263,8 +439,12 @@ int svcprocess_run(ipc::IpcChannel* channel) {
                 ModelLoad(cmdBuf, channel);
                 break;
 
-            case 'g':   // run Graphs.
+            case 'g':   // run Graphs (sync or async).
                 ModelRun(cmdBuf, channel, posixFd);
+                break;
+
+            case 'q':   // query async inference result.
+                ModelQueryResult(cmdBuf, channel);
                 break;
 
             case 'r':   // release model.

--- a/src/Utils/BuildId.hpp
+++ b/src/Utils/BuildId.hpp
@@ -11,7 +11,7 @@
 namespace qnn {
 namespace tools {
 
-inline std::string getBuildId() { return std::string("v2.47.0.260601"); }
+inline std::string getBuildId() { return std::string("v2.47.1.260610"); }
 
 }  // namespace tools
 }  // namespace qnn


### PR DESCRIPTION
## Summary

Implements async model load and parallel inference for cross-process mode,
addressing the request raised in qualcomm/qai-appbuilder#41.

### Changes

**Async model loading**
- `ModelLoad` (`QAIAppSvc`) launches `ModelInitialize` on a background thread
  (`std::async`) and returns immediately in async mode. The `std::future` is
  stored in `g_async_futures`.
- `WaitForAsyncLoad(model_name)` and `WaitForAllAsyncLoads()` ensure that
  subsequent commands (`ModelRun`, `getModelInfo`, `ModelRelease`, `SetPerf`,
  `RelPerf`) block until the background load completes, preventing races.

**Async / parallel inference**
- `ModelRun` gains an optional `async` flag in the IPC command string. When
  set, the HTP graph execution runs on a background thread and the main server
  loop stays free to accept new commands. A unique `request_id` is returned to
  the client immediately.
- New server command `'q'` (`ModelQueryResult`): blocks until the background
  inference identified by `request_id` finishes and returns the result.
- New C++ API on `LibAppBuilder`: `ModelInferenceAsync` / `ModelWaitInference`.
- New pybind11 binding on `QNNContext`: `InferenceAsync` / `InferenceWait`.
- New Python API on `QNNContextProc`: `InferenceAsync(shareMemory, input)` →
  `request_id`; `InferenceWait(request_id, shareMemory)` → output arrays.

**Bug fixes found during review**
- SHM key aliasing: concurrent async inferences for the same model used the
  same `sg_share_mem_map` key, causing UAF. Fixed by using a unique
  `registry_key = share_memory_name + "_" + request_id`.
- Spurious `outputSize.push_back(12345)` sentinel removed from the async
  inference path (it corrupted output-size reporting).
- `WaitForAsyncLoad` return value now checked and acted upon in `getModelInfo`
  and `ModelRelease`.
- Cross-process `_P` pybind11 registrations (`model_initialize`, etc.) were
  gated on `#ifdef _WIN32`; gate removed so Linux also registers them.
- `VectorToShareMem` bounds check changed from `<=` to `<` (off-by-one fix
  that was causing writes one byte past the end of the SHM region).
- `numpy` dependency in `setup.py` pinned to `<=2.4.4` to avoid a runtime
  incompatibility with `numba 0.66` and `qai-hub-models`.

### Test

Validated on Windows on Snapdragon (ARM64EC) with:
- `samples/python/aotgan/aotgan-new.py`: two AotGan instances loaded in
  parallel, dispatched with `InferenceAsync`, collected with `InferenceWait`.
  Wall time ≈ single-model inference time, confirming true parallelism.
- `samples/python/whisper_base_en/whisper_base_en-new.py`: encoder + decoder
  async parallel load, synchronous decoder loop — results unchanged.
