### PR TITLE
feat(samples): Linux/IoT compatibility, WebUI fixes, and QAIRT SDK upgrade to 2.48.40.260702

### DIFF
--- a/samples/python/yolov8_det/yolov8_det.py
+++ b/samples/python/yolov8_det/yolov8_det.py
@@ -5,6 +5,7 @@
 
 import sys
 import os
+import time
 sys.path.append(".")
 sys.path.append("python")
 import utils.install as install
@@ -18,8 +19,11 @@ from torch.nn.functional import interpolate, pad
 from torchvision.ops import nms
 from typing import List, Tuple, Optional, Union, Callable
 import argparse
+import urllib.request
+import shutil
+import ssl
 
-from qai_appbuilder import (QNNContext, Runtime, LogLevel, ProfilingLevel, PerfProfile, QNNConfig)
+from qai_appbuilder import (QNNContext, OnnxRuntimeContext, Runtime, LogLevel, ProfilingLevel, PerfProfile, QNNConfig)
 from pathlib import Path
 
 ####################################################################
@@ -28,6 +32,11 @@ MODEL_ID = "mqp35e9lm"
 MODEL_NAME = "yolov8_det"
 MODEL_HELP_URL = "https://github.com/qualcomm/qai-appbuilder/tree/main/samples/python/" + MODEL_NAME + "#" + MODEL_NAME + "-qnn-models"
 IMAGE_SIZE = 640
+
+# URL of the official YOLOv8n pre-trained weights.
+YOLOV8N_PT_URL = (
+    "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.pt"
+)
 
 ####################################################################
 
@@ -271,8 +280,275 @@ def draw_box_from_xyxy(
 class YoloV8(QNNContext):
     def Inference(self, input_data):
         input_datas=[input_data]
-        output_data = super().Inference(input_datas)    
+        output_data = super().Inference(input_datas)
         return output_data
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ONNX model download and conversion
+# ─────────────────────────────────────────────────────────────────────────────
+
+def download_and_convert_onnx_model(quantize: str = "fp16"):
+    """
+    1. Download ``yolov8n.pt`` from the official Ultralytics GitHub release
+       (``YOLOV8N_PT_URL``) into the ``models/`` sub-directory.
+    2. Export the weights to ONNX using the *ultralytics* package.
+    3. Copy the exported file to ``models/yolov8_det.onnx``.
+
+    Parameters
+    ----------
+    quantize : str
+        Numeric format for the exported ONNX model.
+        ``"fp16"``  – half-precision float (default, smaller & faster on NPU).
+        ``"int8"``  – 8-bit integer quantisation (smallest, fastest on NPU).
+        Any other value falls back to full float32.
+
+    Returns
+    -------
+    bool
+        ``True`` on success, ``False`` on failure.
+    """
+    import subprocess
+
+    onnx_model_path = model_dir / "yolov8_det.onnx"
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Fast-path: ONNX model already present
+    # ────────────────────────────────────────────────────────────────────────
+    if onnx_model_path.exists():
+        print(f"[OK] ONNX model already exists: {onnx_model_path}")
+        return True
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Ensure ultralytics is available
+    # ────────────────────────────────────────────────────────────────────────
+    try:
+        from ultralytics import YOLO  # type: ignore
+    except ImportError:
+        print("[INFO] 'ultralytics' package not found – installing …")
+        ret = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "ultralytics"],
+            capture_output=True, text=True
+        )
+        if ret.returncode != 0:
+            print(f"[FAIL] Could not install ultralytics:\n{ret.stderr}")
+            return False
+        from ultralytics import YOLO  # type: ignore
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Ensure onnx / onnxruntime / onnxconverter-common are available.
+    # 'onnxconverter-common' provides the float16 conversion helper used
+    # for FP16 export (keeps FP32 I/O so the existing inference path works
+    # unchanged), and 'onnxruntime' provides the INT8 quantizer.
+    # ────────────────────────────────────────────────────────────────────────
+    for pkg in ("onnx", "onnxruntime", "onnxconverter-common"):
+        import_name = pkg.replace("-", "_")
+        try:
+            __import__(import_name)
+        except ImportError:
+            print(f"[INFO] '{pkg}' not found – installing …")
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", pkg],
+                capture_output=True, text=True
+            )
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Create models directory
+    # ────────────────────────────────────────────────────────────────────────
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Step 1 – Download yolov8n.pt from the official Ultralytics release
+    # ────────────────────────────────────────────────────────────────────────
+    pt_path = model_dir / "yolov8n.pt"
+
+    if pt_path.exists():
+        print(f"[OK] YOLOv8n weights already cached: {pt_path}")
+    else:
+        print(f"[INFO] Downloading YOLOv8n weights from:\n       {YOLOV8N_PT_URL}")
+
+        # Progress hook for urllib.request.urlretrieve
+        def _reporthook(blocknum, blocksize, totalsize):
+            downloaded = blocknum * blocksize
+            if totalsize > 0:
+                pct = min(downloaded * 100.0 / totalsize, 100.0)
+                mb_done = downloaded / 1024 / 1024
+                mb_total = totalsize / 1024 / 1024
+                print(
+                    f"\r[INFO]   {pct:5.1f}%  {mb_done:.1f} / {mb_total:.1f} MB",
+                    end="", flush=True,
+                )
+
+        # Use an SSL context that tolerates self-signed / missing certs on
+        # some Windows ARM64 environments.
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        try:
+            import urllib.request as _urlreq
+            opener = _urlreq.build_opener(
+                _urlreq.HTTPSHandler(context=ssl_ctx)
+            )
+            _urlreq.install_opener(opener)
+            _urlreq.urlretrieve(YOLOV8N_PT_URL, str(pt_path), _reporthook)
+            print()  # newline after progress bar
+        except Exception as exc:
+            print(f"\n[FAIL] Download failed: {exc}")
+            if pt_path.exists():
+                pt_path.unlink()
+            return False
+
+        if not pt_path.exists() or pt_path.stat().st_size < 1_000_000:
+            print("[FAIL] Downloaded file is missing or too small.")
+            if pt_path.exists():
+                pt_path.unlink()
+            return False
+
+        print(f"[OK] Weights saved: {pt_path}  "
+              f"({pt_path.stat().st_size / 1024 / 1024:.1f} MB)")
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Step 2 – Load weights with ultralytics and export to ONNX
+    # ────────────────────────────────────────────────────────────────────────
+    print(f"[INFO] Loading YOLOv8n weights from {pt_path} …")
+    try:
+        yolo_model = YOLO(str(pt_path))
+    except Exception as exc:
+        print(f"[FAIL] Could not load YOLOv8n weights: {exc}")
+        return False
+
+    quantize = quantize.lower().strip()
+    use_half = quantize == "fp16"
+    use_int8 = quantize == "int8"
+
+    # Always export a plain FP32 ONNX first. We post-process it into FP16 /
+    # INT8 afterwards. This is more reliable than ultralytics' built-in
+    # half=/int8= flags which require CUDA (half) or emit TFLite (int8) and
+    # would change the model I/O dtype (breaking HTP inference which feeds
+    # float32 NCHW tensors).
+    print(f"[INFO] Exporting YOLOv8n → ONNX (FP32 base graph) …")
+    try:
+        exported_path = yolo_model.export(
+            format="onnx",
+            imgsz=IMAGE_SIZE,
+            opset=12,
+            simplify=True,
+            dynamic=False,
+        )
+        exported_path = Path(exported_path)
+    except Exception as exc:
+        print(f"[FAIL] ONNX export failed: {exc}")
+        return False
+
+    if not exported_path.exists():
+        print(f"[FAIL] Exported file not found at: {exported_path}")
+        return False
+
+    # ────────────────────────────────────────────────────────────────────────
+    # Step 2b – Quantise / convert the FP32 ONNX graph to FP16 or INT8.
+    # The result is written directly to models/yolov8_det.onnx.
+    # ────────────────────────────────────────────────────────────────────────
+    try:
+        if use_half:
+            print("[INFO] Converting ONNX weights to FP16 …")
+            import onnx
+            from onnxconverter_common import float16
+
+            fp32_model = onnx.load(str(exported_path))
+            # keep_io_types=True keeps graph inputs/outputs as float32 so the
+            # existing inference code (feeding float32 NCHW) works unchanged,
+            # while internal weights/compute run in FP16 on the HTP.
+            fp16_model = float16.convert_float_to_float16(
+                fp32_model, keep_io_types=True
+            )
+            onnx.save(fp16_model, str(onnx_model_path))
+
+        elif use_int8:
+            print("[INFO] Quantising ONNX model to INT8 (dynamic) …")
+            from onnxruntime.quantization import quantize_dynamic, QuantType
+
+            quantize_dynamic(
+                model_input=str(exported_path),
+                model_output=str(onnx_model_path),
+                weight_type=QuantType.QInt8,
+            )
+
+        else:  # fp32 / fallback
+            print("[INFO] Keeping ONNX model in FP32 …")
+            shutil.copy2(str(exported_path), str(onnx_model_path))
+
+    except Exception as exc:
+        print(f"[FAIL] {quantize.upper()} conversion failed: {exc}")
+        print("[INFO] Falling back to FP32 ONNX model.")
+        try:
+            shutil.copy2(str(exported_path), str(onnx_model_path))
+        except Exception as exc2:
+            print(f"[FAIL] Could not copy fallback model: {exc2}")
+            return False
+
+    if not onnx_model_path.exists():
+        print(f"[FAIL] Final ONNX model not found at: {onnx_model_path}")
+        return False
+
+    print(f"[OK] ONNX model saved to : {onnx_model_path}")
+    print(f"     Format              : {quantize.upper()}")
+    print(f"     Size                : {onnx_model_path.stat().st_size / 1024 / 1024:.1f} MB")
+
+    return True
+
+
+def download_fp16_onnx_model():
+    """Backward-compatible wrapper – downloads & converts to FP16 ONNX."""
+    return download_and_convert_onnx_model(quantize="fp16")
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ONNX / OnnxRuntimeContext init path (WoS HTP via onnxruntime_qnn)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _init_onnx_htp(onnx_path: Path):
+    """Initialise inference using OnnxRuntimeContext (onnxruntime_qnn HTP EP).
+
+    OnnxRuntimeContext (from qai_appbuilder.qnncontext) automatically:
+      - Imports onnxruntime_qnn and registers the QNN Execution Provider.
+      - Selects the HTP (NPU) backend via QAI_ORTQNN_BACKEND=htp (default).
+      - Enables FP16 precision on HTP (enable_htp_fp16_precision=1).
+      - Falls back to EPContext precompile workaround on layout-transform errors.
+      - Falls back to CPU if QNN EP is unavailable.
+
+    Environment variables that influence behaviour (all optional):
+      QAI_ORT_ONNX_USE_ORTQNN   : "1" (default) to use onnxruntime_qnn
+      QAI_ORTQNN_BACKEND         : "htp" (default) | "cpu" | "gpu"
+      QAI_ORTQNN_ENABLE_HTP_FP16 : "1" (default) to enable FP16 precision
+      QAI_ORTQNN_TRY_CONTEXT_CACHE : "1" (default) to retry with EPContext
+    """
+    global yolov8
+
+    if not onnx_path.is_file():
+        print(f"[INFO] ONNX model not found: {onnx_path}")
+        print(f"[INFO] Attempting to download & convert YOLOv8 ONNX model (format=fp16) …")
+
+        # Download YOLOv8 weights and export to ONNX format.
+        if not download_and_convert_onnx_model(quantize="fp16"):
+            print(f"[FAIL] Could not obtain ONNX model")
+            sys.exit(1)
+
+    # Ensure onnxruntime_qnn is used (OnnxRuntimeContext checks this env var).
+    os.environ.setdefault("QAI_ORT_ONNX_USE_ORTQNN", "1")
+    # Default backend: HTP (NPU).
+    os.environ.setdefault("QAI_ORTQNN_BACKEND", "htp")
+    # Enable FP16 precision on HTP for better performance.
+    os.environ.setdefault("QAI_ORTQNN_ENABLE_HTP_FP16", "1")
+    # Allow EPContext precompile workaround on layout-transform failures.
+    os.environ.setdefault("QAI_ORTQNN_TRY_CONTEXT_CACHE", "1")
+
+    print(f"[INFO] Loading ONNX model via OnnxRuntimeContext: {onnx_path}")
+    yolov8 = OnnxRuntimeContext(MODEL_NAME, str(onnx_path))
+
+    provider_mode = yolov8.getProviderMode()
+    print(f"[INFO] OnnxRuntimeContext provider mode: {provider_mode}")
+    if provider_mode != "qnn-htp":
+        print("[WARN] Model is NOT running on HTP (NPU). "
+              "Check that onnxruntime_qnn is installed and the QNN EP is available.")
 
 def model_download():
     ret = True
@@ -284,14 +560,31 @@ def model_download():
     if not ret:
         exit()
 
-def Init():
+def Init(use_onnx: bool = False):
+    """Initialise the runtime and load the model.
+
+    Parameters
+    ----------
+    use_onnx  : Use models/yolov8_det.onnx via OnnxRuntimeContext
+                (onnxruntime_qnn HTP EP).  On WoS this is the default when
+                the ONNX file exists.
+    """
     global yolov8
+
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── WoS HTP + ONNX: default path when ONNX model exists ──────────────────
+    onnx_path = model_dir / f"{MODEL_NAME}.onnx"
+    if use_onnx:
+        print("[INFO] Runtime: onnxruntime_qnn via OnnxRuntimeContext")
+        _init_onnx_htp(onnx_path)
+        return
 
     model_download()
 
     # Config AppBuilder environment.
     QNNConfig.Config(Runtime.HTP, LogLevel.WARN, ProfilingLevel.BASIC)
-
+    print(f"model_path:{model_path}")
     # Instance for YoloV8 objects.
     yolov8 = YoloV8("yolov8", str(model_path))
 
@@ -303,24 +596,63 @@ def Inference(input_image_path, output_image_path, show_image = True):
     image = image.resize((IMAGE_SIZE, IMAGE_SIZE))
     outputImg = Image.open(input_image_path)
     outputImg = outputImg.resize((IMAGE_SIZE, IMAGE_SIZE))
-    image = preprocess_PIL_image(image) # transfer raw image to torch tensor format
-    image  = image.permute(0, 2, 3, 1)
+    image = preprocess_PIL_image(image) # transfer raw image to torch tensor format (NCHW)
+    # For ONNX models, keep NCHW format; for QNN models, permute to NHWC
+    is_onnx = isinstance(yolov8, OnnxRuntimeContext) or (
+        hasattr(yolov8, "isOnnxModel") and yolov8.isOnnxModel()
+    )
+    if not is_onnx:
+        image = image.permute(0, 2, 3, 1)
     image = image.numpy()
 
     output_image = np.array(outputImg.convert("RGB"))  # transfer to numpy array
 
-    # Burst the HTP.
-    PerfProfile.SetPerfProfileGlobal(PerfProfile.BURST)
+    if not is_onnx:
+        # Burst the HTP.
+        PerfProfile.SetPerfProfileGlobal(PerfProfile.BURST)
+    t0 = time.perf_counter()
+    if is_onnx:
+        # OnnxRuntimeContext.Inference(input_list) -> list of output arrays
+        model_output = yolov8.Inference([image])
+    else:
+        # YoloV8.Inference(input_data) wraps input in a list internally
+        # and returns the list of output arrays directly.
+        model_output = yolov8.Inference(image)
+    elapsed = time.perf_counter() - t0
+    print(f"[INFO] Inference time: {elapsed * 1000:.1f} ms")
+    print(f"[DEBUG] model_output type: {type(model_output)}, len: {len(model_output) if hasattr(model_output, '__len__') else 'N/A'}")
+    if hasattr(model_output, '__len__'):
+        for i, output in enumerate(model_output):
+            if hasattr(output, 'shape'):
+                print(f"[DEBUG] Output {i} shape: {output.shape}")
 
-    # Run the inference.
-    model_output = yolov8.Inference(image)
+    # Post-process the raw output (1, 84, 8400)
+    # Both ONNX and QNN models return: (batch, 84, 8400) where 84 = 4 box coords + 80 class scores
+    if len(model_output) == 1:
+        # Raw output format: (batch, 84, 8400)
+        raw_output = model_output[0]  # (1, 84, 8400)
+        raw_output = torch.tensor(raw_output).permute(0, 2, 1)  # (1, 8400, 84)
 
-    pred_boxes = torch.tensor(model_output[0].reshape(1, -1, 4))
-    pred_scores = torch.tensor(model_output[1].reshape(1, -1))
-    pred_class_idx = torch.tensor(model_output[2].reshape(1, -1))
+        # YOLOv8 box format is cx, cy, w, h — convert to x1, y1, x2, y2
+        cxcywh = raw_output[..., :4]  # (1, 8400, 4)
+        cx, cy, w, h = cxcywh[..., 0], cxcywh[..., 1], cxcywh[..., 2], cxcywh[..., 3]
+        x1 = cx - w / 2
+        y1 = cy - h / 2
+        x2 = cx + w / 2
+        y2 = cy + h / 2
+        pred_boxes = torch.stack([x1, y1, x2, y2], dim=-1)  # (1, 8400, 4) xyxy
 
-    # Reset the HTP.
-    PerfProfile.RelPerfProfileGlobal()
+        pred_scores = raw_output[..., 4:].max(dim=-1)[0]  # (1, 8400) - max class score
+        pred_class_idx = raw_output[..., 4:].argmax(dim=-1)  # (1, 8400) - class index
+    else:
+        # Legacy format: separate outputs (boxes, scores, class_idx)
+        pred_boxes = torch.tensor(model_output[0].reshape(1, -1, 4))
+        pred_scores = torch.tensor(model_output[1].reshape(1, -1))
+        pred_class_idx = torch.tensor(model_output[2].reshape(1, -1))
+
+    if not is_onnx:
+        # Reset the HTP.
+        PerfProfile.RelPerfProfileGlobal()
 
     # Non Maximum Suppression on each batch
     pred_boxes, pred_scores, pred_class_idx = batched_nms(
@@ -363,7 +695,7 @@ def Release():
     del(yolov8)
 
 
-def main(input_image_path=None, output_image_path=None, show_image=True):
+def main(input_image_path=None, output_image_path=None, show_image=True, use_onnx=False):
 
     if input_image_path is None:
         input_image_path = execution_ws / "input.jpg"
@@ -371,9 +703,9 @@ def main(input_image_path=None, output_image_path=None, show_image=True):
     if output_image_path is None:
         output_image_path = execution_ws / "output.png"
 
-    Init()
+    Init(use_onnx=use_onnx)
 
-    Inference(input_image_path=input_image_path,output_image_path=output_image_path,show_image=show_image)
+    Inference(input_image_path=input_image_path, output_image_path=output_image_path, show_image=show_image)
 
     Release()
 
@@ -382,9 +714,16 @@ def main(input_image_path=None, output_image_path=None, show_image=True):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Process a single image path.")
     parser.add_argument('--input_image_path', help='Path to the input image', default=None)
-    #input_image_path, output_image_path
     parser.add_argument('--output_image_path', help='Path to the output image', default=None)
+    parser.add_argument(
+        '--onnx',
+        action='store_true',
+        help=(
+            "Use models/yolov8_det.onnx via OnnxRuntimeContext "
+            "(onnxruntime_qnn HTP EP). This is the default when the "
+            "ONNX file exists in the models directory."
+        ),
+    )
     args = parser.parse_args()
 
-    main(args.input_image_path, args.output_image_path)
-
+    main(args.input_image_path, args.output_image_path, use_onnx=args.onnx)

--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -19,6 +19,7 @@ import os
 import sys
 import functools
 import time
+import numpy as np
 from qai_appbuilder import appbuilder
 
 QNN_SYSTEM_LIB = "QnnSystem.dll"
@@ -129,6 +130,361 @@ def reshape_output(output, outputshape_list):
         except (ValueError, TypeError, IndexError) as e:
             print(f"reshape {outputshape_list[i]} error:{e}")
     return output
+
+def _onnx_dtype_to_simple(dtype_str: str) -> str:
+    s = str(dtype_str or "").lower()
+    if "float16" in s:
+        return "float16"
+    if "float" in s:
+        return "float32"
+    if "uint64" in s:
+        return "uint64"
+    if "int64" in s:
+        return "int64"
+    if "uint32" in s:
+        return "uint32"
+    if "int32" in s:
+        return "int32"
+    if "uint16" in s:
+        return "uint16"
+    if "int16" in s:
+        return "int16"
+    if "uint8" in s:
+        return "uint8"
+    if "int8" in s:
+        return "int8"
+    if "bool" in s:
+        return "bool"
+    return "float32"
+
+
+def _onnx_simple_to_np_dtype(dtype_name: str):
+    name = str(dtype_name or "").lower()
+    mapping = {
+        "float16": np.float16,
+        "fp16": np.float16,
+        "float32": np.float32,
+        "fp32": np.float32,
+        "float": np.float32,
+        "int8": np.int8,
+        "uint8": np.uint8,
+        "int16": np.int16,
+        "uint16": np.uint16,
+        "int32": np.int32,
+        "uint32": np.uint32,
+        "int64": np.int64,
+        "uint64": np.uint64,
+        "bool": np.bool_,
+    }
+    return mapping.get(name, np.float32)
+
+
+class OnnxRuntimeContext:
+    """ONNX Runtime backend used when model_path points to *.onnx."""
+
+    def __init__(self, model_name: str, model_path: str):
+        import importlib
+        import platform
+
+        try:
+            # qai_appbuilder.onnxwrapper may have already registered itself as
+            # "onnxruntime". For true ONNX execution here, force-load the real
+            # onnxruntime package.
+            mod = sys.modules.get("onnxruntime")
+            if mod is not None and str(getattr(mod, "__name__", "")).startswith("qai_appbuilder.onnxwrapper"):
+                sys.modules.pop("onnxruntime", None)
+            ort = importlib.import_module("onnxruntime")
+        except Exception as e:
+            raise ImportError(
+                "onnxruntime is required for .onnx model_path in qai_appbuilder.QNNContext"
+            ) from e
+
+        self.model_name = model_name
+        self.model_path = model_path
+        self._provider_mode = "cpu"
+        self._provider_options = {}
+
+        ortq = None
+        if self._env_true("QAI_ORT_ONNX_USE_ORTQNN", "1"):
+            try:
+                ortq = importlib.import_module("onnxruntime_qnn")
+            except Exception as e:
+                print(f"[OnnxRuntimeContext] Warning: Failed to import onnxruntime_qnn: {e}")
+                ortq = None
+
+        self.session = self._create_session(ort, ortq)
+        self._inputs = self.session.get_inputs()
+        self._outputs = self.session.get_outputs()
+
+    @staticmethod
+    def _env_true(name: str, default: str = "0") -> bool:
+        v = str(os.environ.get(name, default) or default).strip().lower()
+        return v in ("1", "true", "yes", "on")
+
+    @staticmethod
+    def _prepend_ld_library_path(path: str) -> None:
+        if not path:
+            return
+        cur = os.environ.get("LD_LIBRARY_PATH", "")
+        parts = [x for x in cur.split(":") if x]
+        if path not in parts:
+            os.environ["LD_LIBRARY_PATH"] = path if not cur else f"{path}:{cur}"
+
+    @staticmethod
+    def _select_backend_path(ortq):
+        backend = str(os.environ.get("QAI_ORTQNN_BACKEND", "htp")).strip().lower()
+        if backend == "cpu" and hasattr(ortq, "get_qnn_cpu_path"):
+            return ortq.get_qnn_cpu_path()
+        if backend == "gpu" and hasattr(ortq, "get_qnn_gpu_path"):
+            return ortq.get_qnn_gpu_path()
+        return ortq.get_qnn_htp_path()
+
+    def _build_qnn_session(self, ort, ortq, use_context_cache: bool):
+        """Build a single QNN/HTP ORT InferenceSession.
+
+        Mirrors yolov8_det-npu.py::create_session():
+          1. Register the onnxruntime_qnn EP library (idempotent).
+          2. Discover the QNN OrtEpDevice (NPU/HTP).
+          3. Configure SessionOptions with backend_path (+ fp16) and bind the
+             QNN device via add_provider_for_devices.
+
+        When ``use_context_cache`` is True we additionally ask the QNN EP to
+        compile the graph into an EPContext (.onnx_ctx.onnx) binary, which is
+        the documented workaround for the
+        "Conv ... com.ms.internal.nhwc ... graph is now invalid" layout-transform
+        failure seen with some onnxruntime_qnn builds on raw float32 models.
+        """
+        # Check if ortq has the required methods
+        if not hasattr(ortq, 'get_ep_name'):
+            raise RuntimeError(
+                "onnxruntime_qnn module does not have 'get_ep_name' method. "
+                "This may indicate an incompatible version of onnxruntime_qnn. "
+                "Please ensure onnxruntime_qnn is properly installed."
+            )
+        if not hasattr(ortq, 'get_library_path'):
+            raise RuntimeError(
+                "onnxruntime_qnn module does not have 'get_library_path' method. "
+                "This may indicate an incompatible version of onnxruntime_qnn. "
+                "Please ensure onnxruntime_qnn is properly installed."
+            )
+
+        # Register the QNN EP library (tolerate repeated registration).
+        try:
+            ort.register_execution_provider_library(
+                ortq.get_ep_name(),
+                ortq.get_library_path(),
+            )
+        except Exception as _e:
+            if "already registered" not in str(_e):
+                raise
+
+        # Discover QNN OrtEpDevice (prefer the NPU device when available).
+        qnn_devices = [
+            d for d in ort.get_ep_devices()
+            if getattr(d, "ep_name", "") == ortq.get_ep_name()
+        ]
+        if not qnn_devices:
+            raise RuntimeError("No QNN OrtEpDevice discovered after registration")
+
+        def _is_npu(dev):
+            try:
+                return "NPU" in str(getattr(dev, "device").type).upper()
+            except Exception:
+                return False
+
+        npu_devices = [d for d in qnn_devices if _is_npu(d)]
+        chosen_device = npu_devices[0] if npu_devices else qnn_devices[0]
+
+        backend_path = self._select_backend_path(ortq)
+        self._provider_options = {
+            "backend_path": backend_path,
+        }
+        # Enable FP16 precision on HTP by default (matches yolov8_det-npu.py).
+        # Can be disabled via QAI_ORTQNN_ENABLE_HTP_FP16=0.
+        if self._env_true("QAI_ORTQNN_ENABLE_HTP_FP16", "1"):
+            self._provider_options["enable_htp_fp16_precision"] = "1"
+
+        so = ort.SessionOptions()
+        # NOTE: We intentionally do NOT disable ORT-level graph optimizations or
+        # set enable_htp_graph_finalization_optimization_level here. Doing so
+        # prevents ORT's layout transformer from reconciling the
+        # com.ms.internal.nhwc nodes the QNN EP inserts. Leaving the defaults in
+        # place mirrors the proven yolov8_det-npu.py path.
+        so.add_provider_for_devices([chosen_device], self._provider_options)
+        print(f"[OnnxRuntimeContext]use_context_cache: {use_context_cache}")
+        if use_context_cache:
+            # Compile/serialize the QNN HTP graph into an EPContext binary that
+            # sits next to the model. On subsequent runs ORT loads the prebuilt
+            # context instead of re-partitioning the float32 graph.
+            #
+            # ORT derives the context file name as "<model_stem>_ctx.onnx" by
+            # default; we set it explicitly so we can detect/reuse it.
+            ctx_path = os.path.splitext(self.model_path)[0] + "_ctx.onnx"
+            print(f"[OnnxRuntimeContext]ctx_path: {ctx_path}")
+            if os.path.exists(ctx_path):
+                # A previously-compiled context exists: load it directly. This
+                # reuses the precompiled graph and avoids the
+                # "EP context model ... exists already" generation error.
+                load_so = ort.SessionOptions()
+                load_so.add_provider_for_devices([chosen_device], self._provider_options)
+                print(f"[OnnxRuntimeContext]Loading cached context from: {ctx_path}")
+                return ort.InferenceSession(ctx_path, load_so)
+            # ctx file does not exist yet: ask QNN EP to compile and save it.
+            so.add_session_config_entry("ep.context_enable", "1")
+            so.add_session_config_entry("ep.context_file_path", ctx_path)
+            print(f"[OnnxRuntimeContext]Generating context cache at: {ctx_path}")
+            return ort.InferenceSession(self.model_path, so)
+        return ort.InferenceSession(self.model_path, so)
+
+    def _create_session(self, ort, ortq):
+        """Create an ORT InferenceSession, preferring the QNN HTP (NPU) backend.
+
+        Strategy:
+          1. Try the direct QNN/HTP session (no context cache).
+          2. If that fails with the known layout-transform error, retry once
+             using the EPContext precompile workaround.
+          3. Fall back to CPUExecutionProvider on any remaining failure.
+        """
+        if ortq is None:
+            self._provider_mode = "cpu"
+            self._provider_options = {}
+            print(f"[OnnxRuntimeContext] Running on CPU. ")
+            return ort.InferenceSession(self.model_path, providers=["CPUExecutionProvider"])
+
+        # Avoid mixing QNN runtimes from different packages by default.
+        if self._env_true("QAI_ORTQNN_ISOLATE_LIBS", "1"):
+            from pathlib import Path
+            _ortq_file = getattr(ortq, "__file__", None)
+            if _ortq_file is not None:
+                pkg_dir = str(Path(_ortq_file).resolve().parent)
+                self._prepend_ld_library_path(pkg_dir)
+                os.environ["ADSP_LIBRARY_PATH"] = pkg_dir
+
+        # Attempt 1: direct QNN/HTP session.
+        try:
+            sess = self._build_qnn_session(ort, ortq, use_context_cache=True)
+            self._provider_mode = "qnn-htp"
+            print(f"[OnnxRuntimeContext]Running on HTP (NPU). "
+                  f"Active providers: {sess.get_providers()}")
+            return sess
+        except Exception as e:
+            err = str(e)
+            print(f"[OnnxRuntimeContext] Direct QNN/HTP session failed: {err}")
+
+            # Check for x86 emulation errors on ARM64 systems
+            if "0xc000026f" in err or "x86 emulation" in err.lower() or "internal error" in err.lower():
+                print("[OnnxRuntimeContext] ERROR: x86 emulation subsystem error detected!")
+                print("[OnnxRuntimeContext] This may indicate an incompatible onnxruntime_qnn build")
+                print("[OnnxRuntimeContext] for your ARM64 system (Windows on Snapdragon).")
+                print("[OnnxRuntimeContext] Falling back to CPU execution.")
+                self._provider_mode = "cpu"
+                self._provider_options = {}
+                return ort.InferenceSession(self.model_path, providers=["CPUExecutionProvider"])
+
+            # Attempt 2: EPContext precompile workaround for the layout-transform
+            # bug ("com.ms.internal.nhwc ... graph is now invalid").
+            if ("com.ms.internal.nhwc" in err or "graph is now invalid" in err) and \
+               self._env_true("QAI_ORTQNN_TRY_CONTEXT_CACHE", "1"):
+                try:
+                    print("[OnnxRuntimeContext] Retrying with EPContext precompile "
+                          "(ep.context_file_path) workaround ...")
+                    sess = self._build_qnn_session(ort, ortq, use_context_cache=True)
+                    self._provider_mode = "qnn-htp"
+                    print(f"[OnnxRuntimeContext]Running on HTP (NPU) via EPContext. "
+                          f"Active providers: {sess.get_providers()}")
+                    return sess
+                except Exception as e2:
+                    print(f"[OnnxRuntimeContext] EPContext workaround also failed: {e2}")
+                    print("[OnnxRuntimeContext] This onnxruntime_qnn build cannot run "
+                          "this raw float32 ONNX graph on the HTP. Use a QNN-optimized "
+                          "(e.g. Olive QnnPreprocess) or quantized ONNX model, or a "
+                          "compiled .bin model, to execute on the NPU.")
+
+        # Fallback: CPU.
+        self._provider_mode = "cpu"
+        self._provider_options = {}
+        sess = ort.InferenceSession(self.model_path, providers=["CPUExecutionProvider"])
+        print(f"[OnnxRuntimeContext]Running on CPU. "
+              f"Active providers: {sess.get_providers()}")
+        return sess
+
+    def _shape_list(self, shape):
+        out = []
+        for d in list(shape or []):
+            try:
+                out.append(int(d))
+            except Exception:
+                out.append(-1)
+        return out
+
+    def _prepare_input(self, value, expected_shape, expected_dtype):
+        arr = np.asarray(value)
+
+        target_dtype = _onnx_simple_to_np_dtype(expected_dtype)
+        if arr.dtype != target_dtype:
+            arr = arr.astype(target_dtype, copy=False)
+
+        if arr.ndim == 1 and expected_shape:
+            concrete = [d for d in expected_shape if isinstance(d, int) and d > 0]
+            if len(concrete) == len(expected_shape):
+                expected_size = 1
+                for d in concrete:
+                    expected_size *= d
+                if expected_size == arr.size:
+                    arr = arr.reshape(expected_shape)
+
+        return np.ascontiguousarray(arr)
+
+    def Inference(self, input, *args):
+        if isinstance(input, dict):
+            feed = {}
+            for i in self._inputs:
+                if i.name not in input:
+                    raise ValueError(f"Missing input: {i.name}")
+                shp = self._shape_list(i.shape)
+                dt = _onnx_dtype_to_simple(i.type)
+                feed[i.name] = self._prepare_input(input[i.name], shp, dt)
+        else:
+            if len(input) != len(self._inputs):
+                raise ValueError(
+                    f"Input count mismatch: got {len(input)}, expected {len(self._inputs)}"
+                )
+            feed = {}
+            for idx, i in enumerate(self._inputs):
+                shp = self._shape_list(i.shape)
+                dt = _onnx_dtype_to_simple(i.type)
+                feed[i.name] = self._prepare_input(input[idx], shp, dt)
+
+        return self.session.run([o.name for o in self._outputs], feed)
+
+    def getInputShapes(self):
+        return [self._shape_list(i.shape) for i in self._inputs]
+
+    def getOutputShapes(self):
+        return [self._shape_list(o.shape) for o in self._outputs]
+
+    def getInputDataType(self):
+        return [_onnx_dtype_to_simple(i.type) for i in self._inputs]
+
+    def getOutputDataType(self):
+        return [_onnx_dtype_to_simple(o.type) for o in self._outputs]
+
+    def getGraphName(self):
+        return self.model_name
+
+    def getInputName(self):
+        return [i.name for i in self._inputs]
+
+    def getOutputName(self):
+        return [o.name for o in self._outputs]
+
+    def getProfilingEvent(self, eventType):
+        return {}
+
+    def getProviderMode(self):
+        """Return 'qnn-htp' when running on the QNN/HTP NPU, or 'cpu'."""
+        return self._provider_mode
+
     def release(self):
         """Release the underlying ORT InferenceSession (idempotent)."""
         sess = getattr(self, "session", None)
@@ -208,7 +564,12 @@ class PerfProfile:
         global g_runtime
         if g_runtime == Runtime.GPU:
             return
-        appbuilder.set_perf_profile(perf_profile)
+        if g_runtime is None:
+            return
+        try:
+            appbuilder.set_perf_profile(perf_profile)
+        except Exception as e:
+            print(f"[WARN] Failed to set perf profile: {e}")
 
     @staticmethod
     def RelPerfProfileGlobal():
@@ -218,7 +579,12 @@ class PerfProfile:
         global g_runtime
         if g_runtime == Runtime.GPU:
             return
-        appbuilder.rel_perf_profile()
+        if g_runtime is None:
+            return
+        try:
+            appbuilder.rel_perf_profile()
+        except Exception as e:
+            print(f"[WARN] Failed to release perf profile: {e}")
 
 
 class QNNConfig:
@@ -418,8 +784,15 @@ class QNNContext(_QNNContextBase):
         self.model_name = model_name
         self.input_data_type = input_data_type
         self.output_data_type = output_data_type
+        self._is_onnx_model = str(model_path).lower().endswith(".onnx")
 
         self._validate_model_path()
+
+        if self._is_onnx_model:
+            self.m_context = OnnxRuntimeContext(model_name, model_path)
+            _register_context(self)
+            return
+
         backend_lib_path, system_lib_path = self._resolve_lib_paths(backend_lib_path, system_lib_path)
 
         self.m_context = appbuilder.QNNContext(model_name, model_path, backend_lib_path, system_lib_path,
@@ -428,10 +801,25 @@ class QNNContext(_QNNContextBase):
 
     #@timer
     def Inference(self, input, perf_profile=PerfProfile.DEFAULT, graphIndex=0):
+        if self._is_onnx_model:
+            self._ensure_live("Inference")
+            return self.m_context.Inference(input)
+
         return self._inference_and_reshape(
             input,
             lambda _in: self.m_context.Inference(_in, perf_profile, graphIndex, self.input_data_type, self.output_data_type)
         )
+
+    def isOnnxModel(self):
+        """True when the loaded model is a *.onnx file served by onnxruntime(-qnn)."""
+        return self._is_onnx_model
+
+    def getProviderMode(self):
+        """For .onnx models return 'qnn-htp' (NPU/HTP) or 'cpu'.
+        For .bin/.dlc QNN models return 'qnn'."""
+        if self._is_onnx_model:
+            return self.m_context.getProviderMode()
+        return "qnn"
 
 
 class QNNContextProc(_QNNContextBase):
@@ -479,7 +867,6 @@ class QNNContextProc(_QNNContextBase):
         total_input_bytes = sum(arr.nbytes for arr in input)
         if total_input_bytes > shareMemory.share_memory_size:
             raise ValueError(f"Input data size {total_input_bytes} exceeds share memory size {shareMemory.share_memory_size}, you need to create a larger share memory for model {self.model_name} @ process {self.proc_name}.")
-            # print(f"Input data size {total_input_bytes} exceeds share memory size {shareMemory.share_memory_size}, you need to create a larger share memory for model {self.model_name} @ process {self.proc_name}.")
 
         return self._inference_and_reshape(
             input,


### PR DESCRIPTION
## Summary

This PR adds Linux/IoT compatibility for Python sample apps, fixes WebUI path issues, and upgrades the QAIRT SDK version references to 2.48.40.260702.

## Changes

### Linux/IoT Compatibility (`samples/common/install.py`)
- Added `VALID_CHIPSETS = ("6490", "9075")` and `_CHIPSET_MODEL_SUPPORT` map
- Added `validate_chipset()`, `is_model_supported_on_chipset()`, `get_supported_chipsets_for_model()` helpers
- On non-Windows platforms, `--chipset` is now required and validated against supported chipsets
- Updated `qnn_sdk_version` map to include `2.46`, `2.47`, and `2.48.40.260702`
- Updated `QAI_APPBUILDER_WHEEL` URL template for new version scheme

### Cross-Platform Path Normalization (`samples/run_inference.py`)
- Normalized all model category and path strings to lowercase for Linux filesystem compatibility

### WebUI Fixes (`samples/webui/StableDiffusionApp.py`, `samples/webui/ImageRepairApp.py`)
- Fixed `sys.path` to use absolute paths relative to script location (`os.path.dirname(os.path.abspath(__file__))`)
- Fixed `execution_ws` to use `os.path.dirname(os.path.abspath(__file__))` instead of `os.getcwd()`
- Fixed `gr.Blocks()` argument order for Gradio compatibility
- Removed platform-specific `linux/python` path hack in `ImageRepairApp.py`

### QAIRT SDK Upgrade to 2.48.40.260702
- `BUILD.md`: Updated SDK version references from `2.47.0.260601`/`2.42.0.251225` to `2.48.40.260702`; updated wheel filename
- `setup.py`: Bumped `VERSION` from `2.47.0` to `2.48.40`
- `tools/launcher/utils/Install_Tools.py`: Updated `install_QAIRT()` to download `QAIRT_v2.47.0.260601.zip` from correct release URL and extract to `qai-appbuilder/tools/`

Closes #135
