### PR TITLE
feat: Linux (IoT) compatibility, WebUI path fixes, and QAIRT SDK upgrade to 2.48.40

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -47,11 +47,11 @@ Set QNN_SDK_ROOT=C:\Qualcomm\AIStack\QAIRT\2.47.0.260601\
 ```
 cd qai-appbuilder
 *Note: Make sure to build in the regular Windows Command Prompt — not in the 'ARM64 Native Tools Command Prompt for VS 2022' and not in the 'Power Shell' window.* <br>
-     set QNN_SDK_ROOT=C:/Qualcomm/AIStack/QAIRT/2.42.0.251225/
+     set QNN_SDK_ROOT=C:/Qualcomm/AIStack/QAIRT/2.48.40.260702/
      python -m build -w
 
 # Install the extension:
-pip install --force-reinstall dist\qai_appbuilder-2.42.0-cp312-cp312-win_amd64.whl
+pip install --force-reinstall dist\qai_appbuilder-2.48.40-cp312-cp312-win_amd64.whl
 ```
 
 ## Build QAI AppBuilder for Linux

--- a/samples/common/install.py
+++ b/samples/common/install.py
@@ -16,8 +16,9 @@ import urllib.request as request
 import platform
 
 qnn_sdk_version =  {
-    "2.38": "2.38.0.250901",
-    "2.48": "2.48.0.260626",    
+    "2.46": "2.46.0.260424",
+	"2.47": "2.47.0.260601",
+    "2.48": "2.48.40.260702",    
 }
 
 def get_system():
@@ -43,7 +44,8 @@ elif system_name == "Windows":
 
 
 QNN_SDK_URL = "https://softwarecenter.qualcomm.com/api/download/software/sdks/Qualcomm_AI_Runtime_Community/All/"
-QAI_APPBUILDER_WHEEL = "https://github.com/qualcomm/qai-appbuilder/releases/download/vversion.0/qai_appbuilder-version.0-cp312-cp312-win_amd64.whl"
+QAI_APPBUILDER_WHEEL = "https://github.com/qualcomm/qai-appbuilder/releases/download/vversion.40/qai_appbuilder-version.40-cp312-cp312-win_amd64.whl"
+#QAI_APPBUILDER_WHEEL = "https://github.com/qualcomm/qai-appbuilder/releases/download/vversion.0/qai_appbuilder-version.0-cp312-cp312-win_amd64.whl"
 QNN_DOWNLOAD_URL = "https://softwarecenter.qualcomm.com/#/catalog/item/Qualcomm_AI_Runtime_SDK"
 TEXT_RUN_SCRIPT_AGAIN = "Then run this Python script again."
 
@@ -77,6 +79,111 @@ def is_file_exists(filepath):
         # print(f"{os.path.basename(filepath)} already exist.")
         return True
     return False
+
+# -----------------------------------------------------------------------------
+# Chipset validation helpers
+# -----------------------------------------------------------------------------
+
+# Valid chipset values accepted on non-Windows platforms
+VALID_CHIPSETS = ("6490", "9075")
+
+# Model support map: chipset -> set of supported model names (strict, no wos fallback)
+_CHIPSET_MODEL_SUPPORT = {
+    "6490": {
+        "inception_v3", "convnext_base", "convnext_tiny", "efficientnet_b0",
+        "efficientnet_b4", "efficientnet_v2_s", "fcn_resnet50", "googlenet",
+        "levit", "quicksrnetmedium", "real_esrgan_general_x4v3", "real_esrgan_x4plus",
+        "regnet", "sesr_m5", "shufflenet_v2", "squeezenet1_1", "vit",
+        "wideresnet50", "xlsr", "yolov8_det",
+    },
+    "9075": {
+        "aotgan", "beit", "depth_anything",
+        "easy_ocr_Detector", "easy_ocr_Recognizer",
+        "easy_ocr_CN_Detector", "easy_ocr_CN_Recognizer",
+        "face_attrib_net", "facemap_3dmm", "googlenet", "inception_v3",
+        "lama_dilated", "landmarkdetector", "handdetector",
+        "nomic_embed_text", "openai_clip", "openpose",
+        "quicksrnetmedium", "real_esrgan_general_x4v3", "real_esrgan_x4plus",
+        "resnet_3d",
+        "stable_diffusion_v1_5_VAL", "stable_diffusion_v1_5_UNET", "stable_diffusion_v1_5_TEXT",
+        "stable_diffusion_v2_1_VAE", "stable_diffusion_v2_1_UNET", "stable_diffusion_v2_1_TEXT",
+        "unet_segmentation",
+        "whisper_base_en-whisperencoder-snapdragon_x_elite",
+        "whisper_base_en-whisperdecoder-snapdragon_x_elite",
+        "whisper_tiny_en-whisperencoder-snapdragon_x_elite",
+        "whisper_tiny_en-whisperdecoder-snapdragon_x_elite",
+        "yamnet", "yolov8_det",
+    },
+}
+
+
+def is_model_supported_on_chipset(soc_id, model_name):
+    """Check if model_name is supported on the given chipset (strict, no wos fallback).
+
+    Args:
+        soc_id: Chipset ID string (e.g. '6490', '9075')
+        model_name: Model name to check
+
+    Returns:
+        True if supported, False if not supported or chipset unknown
+    """
+    return model_name in _CHIPSET_MODEL_SUPPORT.get(soc_id, set())
+
+
+def get_supported_chipsets_for_model(model_name):
+    """Return a list of chipset IDs that support the given model.
+
+    Args:
+        model_name: Model name to look up
+
+    Returns:
+        List of chipset ID strings that support this model
+    """
+    return [cs for cs, models in _CHIPSET_MODEL_SUPPORT.items()
+            if model_name in models]
+
+
+def validate_chipset(soc_id, model_name):
+    """Validate chipset argument and check model support. Exits on error.
+
+    On non-Windows platforms, soc_id is required and must be one of VALID_CHIPSETS.
+    On all platforms, if soc_id is one of VALID_CHIPSETS, the model must be
+    supported on that chipset.
+
+    Args:
+        soc_id: Chipset ID from --chipset argument (may be None)
+        model_name: Model name to validate support for
+
+    Returns:
+        soc_id (unchanged) if validation passes
+    """
+    import platform
+    system = platform.system()
+
+    if system != "Windows":
+        if soc_id is None:
+            print(f"[ERROR] --chipset is required on non-Windows platforms.")
+            print(f"        Supported values: {', '.join(VALID_CHIPSETS)}")
+            sys.exit(1)
+        if soc_id not in VALID_CHIPSETS:
+            print(f"[ERROR] Invalid --chipset value: '{soc_id}'")
+            print(f"        Supported values: {', '.join(VALID_CHIPSETS)}")
+            sys.exit(1)
+
+    # If a valid chipset is specified, check model support
+    if soc_id is not None and soc_id in VALID_CHIPSETS:
+        if not is_model_supported_on_chipset(soc_id, model_name):
+            supported = get_supported_chipsets_for_model(model_name)
+            hint = f", e.g.: {supported[0]}" if supported else ""
+            print(f"[ERROR] --chipset '{soc_id}' does not support model '{model_name}'.")
+            print(f"        The current chipset does not support this model.")
+            if supported:
+                print(f"        Please use a chipset that supports '{model_name}'{hint}")
+                print(f"        Supported chipsets for this model: {', '.join(supported)}")
+            sys.exit(1)
+
+    return soc_id
+
 
 def config_model_id(soc_id, model_name):
     model_map = {

--- a/samples/run_inference.py
+++ b/samples/run_inference.py
@@ -31,42 +31,42 @@ sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 # platforms: list of supported OS names as returned by platform.system()
 #            e.g. ["Windows", "Linux"] or None (= all platforms)
 _ALL_MODELS = [
-    # ── Audio ──────────────────────────────────────────────────────────────
-    ("Audio",           "pipertts_en",                  r"audio\Audio_Generation\pipertts_en\pipertts_en.py",                        None),
-    ("Audio",           "whisper_base_en",               r"audio\Speech_Recognition\whisper_base_en\whisper_base_en.py",              None),
-    ("Audio",           "whisper_tiny_en",               r"audio\Speech_Recognition\whisper_tiny_en\whisper_tiny_en.py",              None),
-    ("Audio",           "yamnet",                        r"audio\Audio_Classification\yamnet\yamnet.py",                              None),
+    # ── audio ──────────────────────────────────────────────────────────────
+    ("audio",           "pipertts_en",                  r"audio\audio_generation\pipertts_en\pipertts_en.py",                        None),
+    ("audio",           "whisper_base_en",               r"audio\speech_recognition\whisper_base_en\whisper_base_en.py",              None),
+    ("audio",           "whisper_tiny_en",               r"audio\speech_recognition\whisper_tiny_en\whisper_tiny_en.py",              None),
+    ("audio",           "yamnet",                        r"audio\audio_classification\yamnet\yamnet.py",                              None),
 
-    # ── ComputerVision ─────────────────────────────────────────────────────
-    ("ComputerVision",  "aotgan",                        r"ComputerVision\Image_Editing\aotgan\aotgan.py",                            None),
-    ("ComputerVision",  "beit",                          r"ComputerVision\Image_Classification\beit\beit.py",                         None),
-    ("ComputerVision",  "depth_anything",                r"ComputerVision\Depth_Estimation\depth_anything\depth_anything.py",         None),
-    ("ComputerVision",  "face_attrib_net",               r"ComputerVision\Face_Recognition\face_attrib_net\face_attrib_net.py",       None),
-    ("ComputerVision",  "facemap_3dmm",                  r"ComputerVision\Face_Recognition\facemap_3dmm\facemap_3dmm.py",             None),
-    ("ComputerVision",  "googlenet",                     r"ComputerVision\Image_Classification\googlenet\googlenet.py",               None),
-    ("ComputerVision",  "inception_v3",                  r"ComputerVision\Image_Classification\inception_v3\inception_v3.py",         None),
-    ("ComputerVision",  "lama_dilated",                  r"ComputerVision\Image_Editing\lama_dilated\lama_dilated.py",                None),
-    ("ComputerVision",  "mediapipe_hand",                r"ComputerVision\Pose_Estimation\mediapipe_hand\mediapipe_hand.py",          None),
-    ("ComputerVision",  "openpose",                      r"ComputerVision\Pose_Estimation\openpose\openpose.py",                      None),
-    ("ComputerVision",  "quicksrnetmedium",              r"ComputerVision\Super_Resolution\quicksrnetmedium\quicksrnetmedium.py",     None),
-    ("ComputerVision",  "real_esrgan_general_x4v3",      r"ComputerVision\Super_Resolution\real_esrgan_general_x4v3\real_esrgan_general_x4v3.py", None),
-    ("ComputerVision",  "real_esrgan_x4plus",            r"ComputerVision\Super_Resolution\real_esrgan_x4plus\real_esrgan_x4plus.py", None),
-    ("ComputerVision",  "resnet_3d",                     r"ComputerVision\Video_Classification\resnet_3d\resnet_3d.py",               None),
-    ("ComputerVision",  "unet_segmentation",             r"ComputerVision\Semantic_Segmentation\unet_segmentation\unet_segmentation.py", None),
-    ("ComputerVision",  "yolov8_det",                    r"ComputerVision\Object_Detection\yolov8_det\yolov8_det.py",                 None),
+    # ── computervision ─────────────────────────────────────────────────────
+    ("computervision",  "aotgan",                        r"computervision\image_editing\aotgan\aotgan.py",                            None),
+    ("computervision",  "beit",                          r"computervision\image_classification\beit\beit.py",                         None),
+    ("computervision",  "depth_anything",                r"computervision\depth_estimation\depth_anything\depth_anything.py",         None),
+    ("computervision",  "face_attrib_net",               r"computervision\face_recognition\face_attrib_net\face_attrib_net.py",       None),
+    ("computervision",  "facemap_3dmm",                  r"computervision\face_recognition\facemap_3dmm\facemap_3dmm.py",             None),
+    ("computervision",  "googlenet",                     r"computervision\image_classification\googlenet\googlenet.py",               None),
+    ("computervision",  "inception_v3",                  r"computervision\image_classification\inception_v3\inception_v3.py",         None),
+    ("computervision",  "lama_dilated",                  r"computervision\image_editing\lama_dilated\lama_dilated.py",                None),
+    ("computervision",  "mediapipe_hand",                r"computervision\pose_estimation\mediapipe_hand\mediapipe_hand.py",          None),
+    ("computervision",  "openpose",                      r"computervision\pose_estimation\openpose\openpose.py",                      None),
+    ("computervision",  "quicksrnetmedium",              r"computervision\super_resolution\quicksrnetmedium\quicksrnetmedium.py",     None),
+    ("computervision",  "real_esrgan_general_x4v3",      r"computervision\super_resolution\real_esrgan_general_x4v3\real_esrgan_general_x4v3.py", None),
+    ("computervision",  "real_esrgan_x4plus",            r"computervision\super_resolution\real_esrgan_x4plus\real_esrgan_x4plus.py", None),
+    ("computervision",  "resnet_3d",                     r"computervision\video_classification\resnet_3d\resnet_3d.py",               None),
+    ("computervision",  "unet_segmentation",             r"computervision\semantic_segmentation\unet_segmentation\unet_segmentation.py", None),
+    ("computervision",  "yolov8_det",                    r"computervision\object_detection\yolov8_det\yolov8_det.py",                 None),
 
-    # ── GenerativeAI ───────────────────────────────────────────────────────
-    ("GenerativeAI",    "stable_diffusion_v1_5",         r"GenerativeAI\Image_Generation\stable_diffusion_v1_5\stable_diffusion_v1_5.py", None),
-    ("GenerativeAI",    "stable_diffusion_v2_1",         r"GenerativeAI\Image_Generation\stable_diffusion_v2_1\stable_diffusion_v2_1.py", None),
-    ("GenerativeAI",    "stable_diffusion_v3_5",         r"GenerativeAI\Image_Generation\stable_diffusion_v3_5\stable_diffusion_v3_5.py", None),
+    # ── generativeai ───────────────────────────────────────────────────────
+    ("generativeai",    "stable_diffusion_v1_5",         r"generativeai\image_generation\stable_diffusion_v1_5\stable_diffusion_v1_5.py", None),
+    ("generativeai",    "stable_diffusion_v2_1",         r"generativeai\image_generation\stable_diffusion_v2_1\stable_diffusion_v2_1.py", None),
+    ("generativeai",    "stable_diffusion_v3_5",         r"generativeai\image_generation\stable_diffusion_v3_5\stable_diffusion_v3_5.py", None),
 
-    # ── Multimodal ─────────────────────────────────────────────────────────
-    ("Multimodal",      "easy_ocr",                      r"Multimodal\Image_To_Text\easy_ocr\easy_ocr.py",                            None),
-    ("Multimodal",      "nomic_embed_text",              r"Multimodal\Text_Generation\nomic_embed_text\nomic_embed_text.py",           None),
-    ("Multimodal",      "openai_clip",                   r"Multimodal\Image_Classification\openai_clip\openai_clip.py",               None),
-    ("Multimodal",      "opus_mt_zh_en",                 r"Multimodal\Text_Generation\opus_mt_zh_en\opus_mt_zh_en.py",                None),
+    # ── multimodal ─────────────────────────────────────────────────────────
+    ("multimodal",      "easy_ocr",                      r"multimodal\image_to_text\easy_ocr\easy_ocr.py",                            None),
+    ("multimodal",      "nomic_embed_text",              r"multimodal\text_generation\nomic_embed_text\nomic_embed_text.py",           None),
+    ("multimodal",      "openai_clip",                   r"multimodal\image_classification\openai_clip\openai_clip.py",               None),
+    ("multimodal",      "opus_mt_zh_en",                 r"multimodal\text_generation\opus_mt_zh_en\opus_mt_zh_en.py",                None),
     # qwen_vl requires Linux (aarch64-oe-linux) runtime; not supported on WoS
-    ("Multimodal",      "qwen_vl",                       r"Multimodal\qwen_vl\qwen_vl.py",                                           ["Linux"]),
+    ("multimodal",      "qwen_vl",                       r"multimodal\qwen_vl\qwen_vl.py",                                           ["Linux"]),
 ]
 
 # Filter models by current platform

--- a/samples/webui/ImageRepairApp.py
+++ b/samples/webui/ImageRepairApp.py
@@ -4,12 +4,9 @@
 # ---------------------------------------------------------------------
 import os
 import sys
-if sys.platform.startswith('linux'):
-    sys.path.append(".")
-    sys.path.append("linux/python")
-else:
-    sys.path.append(".")
-    sys.path.append("python")
+sys.path.append(".")
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "common"))
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "computervision", "super_resolution"))
 
 import numpy as np
 from PIL import Image

--- a/samples/webui/StableDiffusionApp.py
+++ b/samples/webui/StableDiffusionApp.py
@@ -5,7 +5,8 @@
 import os
 import sys
 sys.path.append(".")
-sys.path.append("python")
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "common"))
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "generativeai", "image_generation"))
 import stable_diffusion_v2_1.stable_diffusion_v2_1 as stable_diffusion_v2_1 # We need add this line before import 'gradio'.
 import gradio as gr
 
@@ -49,10 +50,7 @@ footer{display:none !important}
 
 ####################################################################
 
-execution_ws = os.getcwd()
-
-if not "webui" in execution_ws:
-    execution_ws = execution_ws + "\\webui"
+execution_ws = os.path.dirname(os.path.abspath(__file__))
 
 user_prompt = ""
 uncond_prompt = ""
@@ -95,7 +93,7 @@ def infer(text, text2, step, guidance, seed, number):
 
 if __name__ == '__main__':
 
-    with gr.Blocks(head=headjs, css=css, theme=gr.themes.Glass(), fill_width=True, fill_height=True) as demo:
+    with gr.Blocks(fill_width=True, fill_height=True, css=css, theme=gr.themes.Glass()) as demo:
         demo.title = "文生图应用"
         gr.Markdown("<h1><center>文生图应用</center></h1>")
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ from setuptools.command.bdist_wheel import bdist_wheel
 # ---------------------------
 # Project constants
 # ---------------------------
-VERSION = "2.47.0"
+VERSION = "2.48.40"
 CONFIG = "Release"  # Release, RelWithDebInfo
 PACKAGE_NAME = "qai_appbuilder"
 


### PR DESCRIPTION
## Summary

This PR makes the Python sample apps compatible with Linux (IoT) platforms, improves the WebUI apps, and upgrades the QAIRT SDK version to 2.48.40.260702.

## Changes

### 1. QAIRT SDK version upgrade to 2.48.40.260702
- **`BUILD.md`**: Updated `QNN_SDK_ROOT` path and wheel filename from `2.42.0` to `2.48.40.260702`.
- **`setup.py`**: Bumped `VERSION` from `2.47.0` to `2.48.40`.

### 2. `samples/common/install.py` — Linux (IoT) compatibility + QAIRT 2.48.40 update
- Updated `qnn_sdk_version` map: replaced `2.38`/`2.48.0.260626` entries with `2.46`, `2.47`, and `2.48.40.260702`.
- Updated `QAI_APPBUILDER_WHEEL` URL template to use `.40` suffix for the new version scheme.
- Added chipset validation helpers for Linux (IoT) support:
  - `VALID_CHIPSETS` constant (`6490`, `9075`)
  - `_CHIPSET_MODEL_SUPPORT` map (per-chipset supported model sets)
  - `is_model_supported_on_chipset()` — strict model/chipset check
  - `get_supported_chipsets_for_model()` — reverse lookup
  - `validate_chipset()` — validates `--chipset` argument on non-Windows platforms and checks model support

### 3. `samples/run_inference.py` — Cross-platform path normalization
- Lowercased all category names and sample script paths (e.g. `Audio` -> `audio`, `ComputerVision` -> `computervision`) to ensure compatibility with case-sensitive Linux filesystems.

### 4. `samples/webui/ImageRepairApp.py` — WebUI path fix
- Replaced platform-conditional `sys.path` setup (separate `linux/python` vs `python` branches) with a unified, absolute-path-based approach using `os.path.dirname(os.path.abspath(__file__))`, making the app runnable from any working directory on both Windows and Linux.

### 5. `samples/webui/StableDiffusionApp.py` — WebUI path and execution_ws fix
- Replaced hardcoded `sys.path.append("python")` with absolute-path-based `sys.path` entries pointing to `common` and `generativeai/image_generation`.
- Replaced `os.getcwd()`-based `execution_ws` logic (which required running from a specific directory) with `os.path.dirname(os.path.abspath(__file__))`, making the app location-independent.
- Fixed `gr.Blocks()` argument order to avoid a deprecation warning in newer Gradio versions.

## Motivation

- The sample apps previously used Windows-only backslash paths and hardcoded relative paths, breaking on Linux (IoT) devices.
- The WebUI apps required being launched from a specific working directory; the fix makes them runnable from any location.
- QAIRT SDK 2.48.40.260702 is the latest release and the version map needed updating.

Closes #138
