### PR TITLE
docs: streamline QUICK-START guides

### DIFF
--- a/tools/qaimodelbuilder/Build.bat
+++ b/tools/qaimodelbuilder/Build.bat
@@ -1,0 +1,331 @@
+@echo off
+REM ===========================================================================
+REM Build.bat - Compile the V2 WebUI frontend into the production SPA bundle
+REM             (frontend/dist) that Start.bat / apps.api serves at runtime.
+REM
+REM The Python backend is interpreted (no compile step); only the Vue/Vite
+REM frontend needs building. After changing frontend source, run this script
+REM once to refresh frontend/dist, then (re)launch Start.bat. After changing
+REM ONLY backend code, you can skip this script and just restart Start.bat.
+REM
+REM Usage:
+REM   Build.bat            Fast build: vite build only (skips typecheck /
+REM                        lint / unit tests). Best for the iteration loop.
+REM   Build.bat --full     Full verified build: gen:types + typecheck + lint +
+REM                        unit tests + build. Use before sharing / releasing.
+REM   Build.bat --install  Force pnpm install first (e.g. after deps change).
+REM                        By default install is skipped when node_modules is
+REM                        already present (fastest iteration).
+REM   Build.bat --clean    Wipe node_modules + pnpm-lock.yaml integrity, then
+REM                        do a fresh pnpm install. Use when node_modules is
+REM                        corrupt (e.g. ERR_MODULE_NOT_FOUND for a transitive
+REM                        dep, or when copied across OS/arch boundaries).
+REM   Build.bat --desktop  ALSO compile the Tauri desktop app (Rust shell) after
+REM                        refreshing frontend/dist, producing the installer(s)
+REM                        (.msi/.exe) under
+REM                        desktop\src-tauri\target\release\bundle\. Required
+REM                        whenever you change the Rust shell (desktop\src-tauri
+REM                        \src\*.rs) OR the frontend, so the bundled desktop app
+REM                        picks up both. Plain Build.bat only refreshes
+REM                        frontend/dist (Web/Start.bat mode); the desktop shell
+REM                        is NOT recompiled without this flag.
+REM   Build.bat --desktop-dev
+REM                        Refresh frontend/dist then launch `cargo tauri dev`
+REM                        (debug desktop window, hot Rust rebuild). Does NOT
+REM                        produce an installer; for local desktop verification.
+REM
+REM   Flags compose, e.g. `Build.bat --full --desktop` does a fully-verified
+REM   frontend build then a release desktop bundle.
+REM ===========================================================================
+setlocal EnableDelayedExpansion
+
+set "ROOT_DIR=%~dp0"
+set "MODE=fast"
+set "DO_INSTALL=0"
+set "DO_CLEAN=0"
+set "DO_DESKTOP=0"
+set "DESKTOP_MODE=build"
+:parse_args
+if "%~1"=="" goto args_done
+if /I "%~1"=="--help" goto print_help
+if /I "%~1"=="-h" goto print_help
+if /I "%~1"=="/?" goto print_help
+if /I "%~1"=="--full" set "MODE=full"
+if /I "%~1"=="--install" set "DO_INSTALL=1"
+if /I "%~1"=="--clean" ( set "DO_CLEAN=1" & set "DO_INSTALL=1" )
+if /I "%~1"=="--desktop" set "DO_DESKTOP=1"
+if /I "%~1"=="--desktop-dev" ( set "DO_DESKTOP=1" & set "DESKTOP_MODE=dev" )
+shift
+goto parse_args
+:args_done
+
+echo.
+echo  +------------------------------------------+
+echo  ^|   QAI ModelBuilder  -  Building WebUI    ^|
+echo  +------------------------------------------+
+echo.
+
+REM -- Node.js / pnpm PATH injection -----------------------------------------
+REM Setup.bat installs a portable ARM64 Node into %LOCALAPPDATA%\QAIModelBuilder
+REM \node and enables pnpm there via corepack. Build.bat runs standalone (not
+REM through Setup.bat), so prepend that dir to PATH here too. If absent, fall
+REM back to whatever node/pnpm is already on PATH.
+set "NODE_DIR=%LOCALAPPDATA%\QAIModelBuilder\node"
+if exist "%NODE_DIR%\node.exe" set "PATH=%NODE_DIR%;%PATH%"
+
+REM Disable corepack's interactive download prompt. The very first time
+REM corepack actually has to download a pnpm tarball from npmjs (which
+REM happens lazily, sometimes on the first real `pnpm install` rather than
+REM at `corepack enable` / `prepare` time), it asks "Do you want to
+REM continue? [Y/n]" and hangs the build. Setting this env var makes
+REM corepack just download silently. Setup.bat pre-warms the download so
+REM in normal flow this is a belt-and-suspenders fallback.
+set "COREPACK_ENABLE_DOWNLOAD_PROMPT=0"
+
+REM Verify pnpm is reachable before doing anything; give a clear hint otherwise.
+where pnpm >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] pnpm not found. Node.js / pnpm is missing.
+    echo [ERROR] Run Setup.bat first ^(it installs portable ARM64 Node + pnpm into
+    echo [ERROR] %NODE_DIR%^), then re-run Build.bat.
+    exit /b 1
+)
+
+pushd "%ROOT_DIR%frontend" || (echo [ERROR] frontend not found & exit /b 1)
+
+REM 1. Install dependencies (skipped when node_modules already present).
+REM    A non-frozen install is used so a drifted lockfile does not block.
+REM
+REM Detection of corrupted node_modules: even when node_modules\.bin exists,
+REM transitive deps may be missing (e.g. esbuild absent under
+REM node_modules/vite/node_modules/, leading to "ERR_MODULE_NOT_FOUND" when
+REM vite starts). We probe for a few known-critical packages — if any are
+REM missing, force a fresh install.
+if not exist "node_modules\.bin" set "DO_INSTALL=1"
+if not exist "node_modules\vite" set "DO_INSTALL=1"
+if not exist "node_modules\esbuild" set "DO_INSTALL=1"
+if not exist "node_modules\vue" set "DO_INSTALL=1"
+
+REM --clean: nuke node_modules entirely before installing. Use this when a
+REM regular `pnpm install` cannot heal the tree (e.g. node_modules copied
+REM across OS/arch, hard-linking confused, integrity-mismatch).
+if "%DO_CLEAN%"=="1" (
+    if exist "node_modules" (
+        echo [INFO] --clean: removing node_modules ^(this may take a minute^)
+        rmdir /s /q "node_modules" 2>nul
+    )
+)
+
+if "%DO_INSTALL%"=="1" (
+    echo [INFO] pnpm install
+    REM --config.confirmModulesPurge=false suppresses pnpm's interactive
+    REM "The modules directory ... will be removed and reinstalled from
+    REM scratch. Proceed? (Y/n)" prompt. pnpm asks this whenever node_modules
+    REM was created by a DIFFERENT pnpm major (e.g. after Setup.bat bumped the
+    REM pinned pnpm version), which would otherwise HANG this non-interactive
+    REM build script waiting for keyboard input. Auto-accepting is correct here:
+    REM a from-scratch reinstall is exactly what we want when the store layout
+    REM is incompatible.
+    call pnpm install --config.confirmModulesPurge=false || goto err
+) else (
+    echo [INFO] node_modules present; skipping install ^(use --install to force, --clean to wipe+reinstall^)
+)
+
+if "%MODE%"=="full" goto full
+
+REM Fast path: vite build only (frontend/dist refreshed).
+echo [INFO] Fast build (vite build only; skipping typecheck/lint/test)
+call pnpm exec vite build || goto err
+goto done
+
+:full
+REM Full path: regenerate types + full verification + build.
+echo [INFO] Full verified build (gen:types + typecheck + lint + test + build)
+call pnpm gen:types || goto err
+call pnpm typecheck || goto err
+call pnpm lint || goto err
+call pnpm test || goto err
+call pnpm build || goto err
+
+:done
+popd
+echo.
+echo [INFO] Build complete. frontend\dist refreshed.
+
+REM -- Optional: compile the Tauri desktop app (Rust shell) -------------------
+REM Plain Build.bat stops here (Web/Start.bat mode). With --desktop / --desktop-dev
+REM we ALSO (re)compile the desktop shell so a change in desktop\src-tauri\src\*.rs
+REM (or the just-rebuilt frontend/dist it embeds) makes it into the desktop app.
+if "%DO_DESKTOP%"=="1" goto desktop
+
+echo [INFO] Now (re)launch Start.bat to serve the new bundle (Start.bat will
+echo        auto-open your browser at the chosen URL once the server is ready).
+endlocal
+exit /b 0
+
+REM ===========================================================================
+REM Desktop (Tauri) build
+REM ===========================================================================
+:desktop
+echo.
+echo  +------------------------------------------+
+echo  ^|   QAI ModelBuilder  -  Building Desktop  ^|
+echo  +------------------------------------------+
+echo.
+
+REM -- Rust / cargo PATH injection -------------------------------------------
+REM rustup installs cargo into %USERPROFILE%\.cargo\bin. Build.bat may run from
+REM a shell that does not have it on PATH (e.g. a fresh GUI-launched cmd), so
+REM prepend it here, mirroring the Node PATH injection above. If absent, fall
+REM back to whatever cargo is already on PATH.
+set "CARGO_BIN=%USERPROFILE%\.cargo\bin"
+if exist "%CARGO_BIN%\cargo.exe" set "PATH=%CARGO_BIN%;%PATH%"
+
+REM Verify cargo is reachable.
+where cargo >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] cargo not found. The Rust toolchain is required to build the
+    echo [ERROR] desktop app. Install it from https://rustup.rs ^(adds cargo to
+    echo [ERROR] %CARGO_BIN%^), then re-run Build.bat --desktop.
+    endlocal
+    exit /b 1
+)
+
+REM Verify the `cargo tauri` subcommand (tauri-cli) is installed. It is NOT a
+REM project dependency in Cargo.toml; it is a global cargo subcommand. Give a
+REM precise install hint rather than letting `cargo tauri` fail cryptically.
+cargo tauri --version >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] `cargo tauri` subcommand not found ^(tauri-cli is not installed^).
+    echo [ERROR] Install it once with:
+    echo [ERROR]     cargo install tauri-cli --version ^^^>=2.0.0 --locked
+    echo [ERROR] then re-run Build.bat --desktop. ^(First run also needs the
+    echo [ERROR] Visual Studio C++ build tools + WebView2 runtime on Windows.^)
+    endlocal
+    exit /b 1
+)
+
+pushd "%ROOT_DIR%desktop\src-tauri" || (echo [ERROR] desktop\src-tauri not found & endlocal & exit /b 1)
+
+if "%DESKTOP_MODE%"=="dev" goto desktop_dev
+
+echo [INFO] Building release desktop bundle ^(this can take several minutes^)
+cargo tauri build
+set "DESKTOP_EXIT=%ERRORLEVEL%"
+popd
+if not "%DESKTOP_EXIT%"=="0" goto err_desktop
+echo.
+echo [INFO] Desktop build complete. Installer(s) under:
+echo        desktop\src-tauri\target\release\bundle\
+
+REM Note: WebView2 Fixed Version Runtime (~811 MB) is NOT copied into the
+REM build output. The exe reads it from data\bin\webview2\ at runtime
+REM (installed by Setup.bat --desktop). For standalone distribution,
+REM ensure the target machine runs Setup.bat --desktop first.
+if exist "%ROOT_DIR%data\bin\webview2" (
+    echo [INFO] WebView2 Fixed Version available at data\bin\webview2\
+    echo [INFO] ^(exe reads it at runtime; not bundled into installer output^)
+) else (
+    echo [WARN] data\bin\webview2\ not found. Run Setup.bat --desktop to install.
+    echo [WARN] The desktop exe will fall back to system WebView2 Evergreen Runtime.
+)
+endlocal
+exit /b 0
+
+:desktop_dev
+echo [INFO] Launching `cargo tauri dev` ^(debug desktop window; Ctrl+C to stop^)
+REM Empty beforeDevCommand in tauri.conf.json means Tauri serves the
+REM existing frontend/dist we just rebuilt (no separate vite dev server).
+cargo tauri dev
+set "DESKTOP_EXIT=%ERRORLEVEL%"
+popd
+if not "%DESKTOP_EXIT%"=="0" goto err_desktop
+endlocal
+exit /b 0
+
+:err_desktop
+echo.
+echo [ERROR] Desktop build failed (exit code %DESKTOP_EXIT%).
+endlocal ^& exit /b %DESKTOP_EXIT%
+
+:err
+set "EXIT_CODE=%ERRORLEVEL%"
+popd
+echo.
+echo [ERROR] Build failed (exit code %EXIT_CODE%).
+endlocal ^& exit /b %EXIT_CODE%
+
+REM ===========================================================================
+REM  --help / -h / /?  (does nothing else; pure documentation)
+REM ===========================================================================
+:print_help
+echo.
+echo  QAIModelBuilder - Build.bat
+echo  Compiles the V2 WebUI frontend ^(Vue/Vite -^> frontend\dist^) and, with
+echo  --desktop, the Tauri desktop shell ^(desktop\src-tauri -^> installer^).
+echo  The Python backend is interpreted and needs NO build step; restart
+echo  Start.bat to pick up backend-only changes.
+echo.
+echo  USAGE:
+echo      Build.bat [options]
+echo.
+echo  OPTIONS:
+echo      ^(no flag^)      Fast frontend build: `vite build` only ^(skips
+echo                     typecheck / lint / unit tests^). Best for the
+echo                     iteration loop. Refreshes frontend\dist.
+echo.
+echo      --full         Full verified frontend build:
+echo                         gen:types + typecheck + lint + test + build.
+echo                     Use before sharing / releasing.
+echo.
+echo      --install      Force `pnpm install` first ^(e.g. after deps change^).
+echo                     By default install is skipped when node_modules is
+echo                     already present ^(fastest iteration^).
+echo.
+echo      --clean        Wipe node_modules + reinstall from scratch. Use when
+echo                     node_modules is corrupt ^(e.g. ERR_MODULE_NOT_FOUND
+echo                     for a transitive dep, or copied across OS/arch^).
+echo                     Implies --install.
+echo.
+echo      --desktop      ALSO compile the Tauri desktop app ^(Rust shell^)
+echo                     after refreshing frontend\dist, producing the
+echo                     installer^(s^) ^(.msi/.exe^) under
+echo                         desktop\src-tauri\target\release\bundle\.
+echo                     Required whenever you change desktop\src-tauri\src\*.rs
+echo                     OR the frontend, so the bundled desktop app picks
+echo                     up both. Plain Build.bat only refreshes frontend\dist
+echo                     ^(Web/Start.bat mode^); the desktop shell is NOT
+echo                     recompiled without this flag.
+echo.
+echo      --desktop-dev  Refresh frontend\dist then launch `cargo tauri dev`
+echo                     ^(debug desktop window, hot Rust rebuild^). Does NOT
+echo                     produce an installer; for local desktop verification.
+echo.
+echo      --help, -h, /? Show this help and exit ^(builds nothing^).
+echo.
+echo  NOTES:
+echo      * Flags compose. `Build.bat --full --desktop` does a fully-verified
+echo        frontend build then a release desktop bundle.
+echo      * --desktop / --desktop-dev need the Rust toolchain + tauri-cli.
+echo        Setup.bat does NOT install them by default ^(opt-in to keep the
+echo        base install slim^). Enable them once with:
+echo            Setup.bat --desktop
+echo        which runs Step 5c ^(rustup + `cargo install tauri-cli --locked`,
+echo        ~600MB download + 5-10min compile on ARM64^). Or install manually:
+echo            https://rustup.rs    ^(Rust toolchain^)
+echo            cargo install tauri-cli --version "^>=2.0.0" --locked
+echo.
+echo  EXAMPLES:
+echo      Build.bat                     Fast iteration build of the Web UI.
+echo      Build.bat --full              Fully-verified Web UI build.
+echo      Build.bat --desktop           Web UI + release desktop installer.
+echo      Build.bat --desktop-dev       Web UI + live debug desktop window.
+echo      Build.bat --full --desktop    Fully-verified + release desktop.
+echo      Build.bat --clean             Heal a corrupt node_modules.
+echo.
+echo  After a frontend build:
+echo      Start.bat ^(serve the new bundle^)  ^|  Run the desktop installer
+echo      under desktop\src-tauri\target\release\bundle\
+echo.
+endlocal
+exit /b 0

--- a/tools/qaimodelbuilder/QUICK-START.md
+++ b/tools/qaimodelbuilder/QUICK-START.md
@@ -1,8 +1,8 @@
 # Build & Run — Quick Guide
 
-> Three usage modes + one cheat-sheet.
+> Two usage modes + one cheat-sheet.
 >
-> 中文版：[`QUICK-START.zh-CN.md`](QUICK-START.zh-CN.md)。
+> 中文版：[`QUICK-START.zh-CN.md`](QUICK-START.zh-CN.md).
 
 > **Platform**: Windows on Snapdragon (ARM64). Run every `.bat` from the repo root
 > by double-click or in `cmd.exe`. The scripts auto-download uv / Python 3.13 ARM64 /
@@ -11,13 +11,12 @@
 
 ---
 
-## Three modes at a glance
+## Two modes at a glance
 
 | Mode | Scripts | Who it's for | First-time prep | Daily run |
 |---|---|---|---|---|
 | **A. Dev mode (run from source)** | `Setup.bat` → `Build.bat` → `Start.bat` | Code changes / debugging / contributors | `Setup.bat` + `Build.bat` | `Start.bat` (backend change) / `Build.bat` + `Start.bat` (frontend change) |
-| **B. Desktop app (Tauri)** | `Setup.bat --desktop` → `Build.bat --desktop` | Want a standalone `.exe` / `.msi` installer | `Setup.bat --desktop` | Run the installer under `desktop\src-tauri\target\release\bundle\` |
-| **C. Release artifact (External / Internal)** | `Release.bat [version] [--internal]` | Packaging for end-users | `Setup.bat` once | Ship archive from `dist\release\` → user extracts → runs `Setup.bat` → `Start.bat` |
+| **B. Release artifact (External / Internal)** | `Release.bat [version] [--internal]` | Packaging for end-users | `Setup.bat` once | Ship archive from `.build\release\` → user extracts → runs `Setup.bat` → `Start.bat` |
 
 ---
 
@@ -41,7 +40,6 @@ Common flags:
 |---|---|
 | `--no-builder` | Skip QAIRT SDK / VS toolchain (~2 GB saved when you won't convert models) |
 | `--dev` | Also install contributor toolchain (pytest / mypy / ruff / playwright + Chromium) |
-| `--desktop` | Also install Rust + tauri-cli + WebView2, preparing the desktop build |
 | `--no-pause` | Don't pause at the end (use from CI) |
 
 > Idempotent — safe to re-run. **`data/` is NOT tracked in git**; delete it and
@@ -56,8 +54,6 @@ must be built into `frontend\dist\` so `Start.bat` can serve it:
 Build.bat              REM Fast incremental: vite build only (iteration loop)
 Build.bat --full       REM Verified: gen:types + typecheck + lint + test + build (pre-commit/pre-release)
 Build.bat --clean      REM node_modules is corrupt: wipe and reinstall
-Build.bat --desktop    REM Also produce the Tauri desktop release installer
-Build.bat --desktop-dev REM Debug desktop shell (`cargo tauri dev`, Rust hot-reload)
 ```
 
 > **Changed Python backend?** Just restart `Start.bat`; you do NOT need `Build.bat`.
@@ -66,14 +62,12 @@ Build.bat --desktop-dev REM Debug desktop shell (`cargo tauri dev`, Rust hot-rel
 ### Launching the server
 
 ```cmd
-Start.bat              REM Normal: spawn server in a new window, auto-open browser
-Start.bat --reload     REM Hot-reload (development)
+Start.bat
 ```
 
-Port is auto-selected (default 8989, falls back to 8088 / 7799 / 12989 / 18989 /
-28989 if occupied). The actual URL is
-written to `data\runtime\server.endpoint.json` and the browser is opened to the
-right address automatically. Ctrl+C to stop.
+The server picks an available port at startup and writes the resolved URL to
+`data\runtime\server.endpoint.json`; the browser is opened to the right address
+automatically. Press `Ctrl+C` to stop.
 
 ### Other handy entry points
 
@@ -86,39 +80,20 @@ right address automatically. Ctrl+C to stop.
 
 ---
 
-## B. Desktop app (Tauri)
-
-Package the WebUI as a standalone `.exe` / `.msi` so end-users never see a browser.
-
-```cmd
-Setup.bat --desktop          REM First time: install Rust + tauri-cli + WebView2 runtime
-Build.bat --desktop          REM Produce release installer
-```
-
-Artifacts: `desktop\src-tauri\target\release\bundle\` (`.msi` / `.exe`).
-
-Local desktop debugging (no installer):
-
-```cmd
-Build.bat --desktop-dev      REM Launch cargo tauri dev with Rust hot-reload
-```
-
----
-
-## C. Release artifact (for end-users)
+## B. Release artifact (for end-users)
 
 `Release.bat` runs the full pipeline: clean → frontend build → factory compile →
 assemble → write `build_info.json` → sanitize internal-only assets (when external) →
 manifest whitelist check → archive.
 
 ```cmd
-Release.bat                  REM Default: external edition, version 2.0.0
-Release.bat 2.1.0            REM External edition, custom version
+Release.bat                  REM Default: external edition, version 3.0.0
+Release.bat 3.1.0            REM External edition, custom version
 Release.bat --internal       REM Internal full-feature edition (keeps internal providers / telemetry)
-Release.bat 2.1.0 --internal REM Combined
+Release.bat 3.1.0 --internal REM Combined
 ```
 
-Output: directory + archive under `dist\release\`; `build_info.json` self-reports
+Output: directory + archive under `.build\release\`; `build_info.json` self-reports
 version and edition.
 
 **End-user install flow** (what the user does after receiving the release archive):
@@ -141,10 +116,9 @@ Extract release archive  →  Setup.bat  →  Start.bat
 | Changed frontend deps (`package.json`) | `Build.bat --install` |
 | `node_modules` is broken | `Build.bat --clean` |
 | Run pytest / write contributor tests | `Setup.bat --dev` once, then `Console.bat` to enter venv |
-| Want the desktop app | `Setup.bat --desktop` + `Build.bat --desktop` |
 | Cut a release for end-users | `Release.bat [version]` |
 | Run a one-shot CLI command | `qai.bat <args>` |
 | Install an extra Python pkg temporarily | `Console.bat` then `pip install <pkg>` |
 | Full cleanup (keep `data/`) | `Uninstall.bat` (or `--all` for deeper cleanup) |
 
-> **Every script supports `--help` / `-h` / `/?`** — e.g. `Build.bat --help` lists every flag.
+> **`Setup.bat` / `Build.bat` / `Uninstall.bat` support `--help` / `-h` / `/?`** — e.g. `Build.bat --help` lists every flag. `Release.bat` accepts `--help` and `/?`. `Start.bat` / `qai.bat` forward any extra arguments to the underlying Python entry point.

--- a/tools/qaimodelbuilder/QUICK-START.zh-CN.md
+++ b/tools/qaimodelbuilder/QUICK-START.zh-CN.md
@@ -1,6 +1,6 @@
 # 编译与运行 快速指南
 
-> 三种使用模式 + 一张速查表。
+> 两种使用模式 + 一张速查表。
 >
 > 英文版：[`QUICK-START.md`](QUICK-START.md)。
 
@@ -10,13 +10,12 @@
 
 ---
 
-## 一图看懂三种模式
+## 一图看懂两种模式
 
 | 模式 | 用什么 | 适合谁 | 第一次准备 | 日常启动 |
 |---|---|---|---|---|
 | **A. 开发模式（源码运行）** | `Setup.bat` → `Build.bat` → `Start.bat` | 改代码 / 调试 / 贡献者 | `Setup.bat` + `Build.bat` | `Start.bat`（改后端）/ `Build.bat` + `Start.bat`（改前端） |
-| **B. 桌面 App（Tauri）** | `Setup.bat --desktop` → `Build.bat --desktop` | 想要一个独立 .exe / .msi 安装包 | `Setup.bat --desktop` | 运行 `desktop\src-tauri\target\release\bundle\` 下的安装包 |
-| **C. 发布包（External / Internal）** | `Release.bat [版本号] [--internal]` | 打包给最终用户 | `Setup.bat` 一次 | `dist\release\` 下的归档 → 解压 → 跑 `Setup.bat` → `Start.bat` |
+| **B. 发布包（External / Internal）** | `Release.bat [版本号] [--internal]` | 打包给最终用户 | `Setup.bat` 一次 | `.build\release\` 下的归档 → 解压 → 跑 `Setup.bat` → `Start.bat` |
 
 ---
 
@@ -38,7 +37,6 @@ Setup.bat
 |---|---|
 | `--no-builder` | 跳过 QAIRT SDK / VS 工具链（不做模型转换时省 ~2 GB） |
 | `--dev` | 额外装贡献者工具链（pytest / mypy / ruff / playwright + Chromium） |
-| `--desktop` | 额外装 Rust + tauri-cli + WebView2，准备桌面 App 构建 |
 | `--no-pause` | 安装完不暂停（CI 调用时用） |
 
 > 一次跑通即可，幂等可重复跑。**`data/` 不在仓库里**，删了重跑 `Setup.bat` 即可重生。
@@ -51,8 +49,6 @@ Setup.bat
 Build.bat              REM 快速增量：仅 vite build（开发迭代用）
 Build.bat --full       REM 完整：gen:types + typecheck + lint + test + build（提交/发布前用）
 Build.bat --clean      REM node_modules 损坏时：清空重装
-Build.bat --desktop    REM 顺带打 Tauri 桌面 release 安装包
-Build.bat --desktop-dev REM 调试桌面壳（`cargo tauri dev` 热重载）
 ```
 
 > **改后端 Python**：直接 `Start.bat` 重启即可，不用跑 `Build.bat`。
@@ -61,11 +57,11 @@ Build.bat --desktop-dev REM 调试桌面壳（`cargo tauri dev` 热重载）
 ### 启动服务
 
 ```cmd
-Start.bat              REM 普通模式：新窗口启动 server，自动开浏览器
-Start.bat --reload     REM 热重载（开发调试）
+Start.bat
 ```
 
-端口动态选择（默认 8989，被占就回退到 8088 / 7799 / 12989 / 18989 / 28989），实际 URL 写入 `data\runtime\server.endpoint.json`，浏览器会自动打开正确地址。Ctrl+C 即停。
+Server 启动时自动选取可用端口，实际 URL 写入
+`data\runtime\server.endpoint.json`，浏览器会自动打开正确地址。按 `Ctrl+C` 停止。
 
 ### 其他便捷入口
 
@@ -78,39 +74,19 @@ Start.bat --reload     REM 热重载（开发调试）
 
 ---
 
-## B. 桌面 App（Tauri）
-
-把 WebUI 打包成独立 `.exe` / `.msi`，用户不必看到浏览器。
-
-```cmd
-Setup.bat --desktop          REM 第一次：装 Rust + tauri-cli + WebView2 运行时
-Build.bat --desktop          REM 出 release 安装包
-```
-
-产物位置：`desktop\src-tauri\target\release\bundle\`（`.msi` / `.exe`）。
-
-本地调试桌面壳（不出包）：
-
-```cmd
-Build.bat --desktop-dev      REM 启动 cargo tauri dev，热重载 Rust 改动
-```
-
-
----
-
-## C. 发布包（给最终用户）
+## B. 发布包（给最终用户）
 
 `Release.bat` 跑完整流水线：clean → 前端 build → factory 编译 → assemble → 写
 `build_info.json` → 清洗 internal-only 资产（external 时） → manifest 白名单校验 → 归档。
 
 ```cmd
-Release.bat                  REM 默认：external 版，版本号 2.0.0
-Release.bat 2.1.0            REM external 版，指定版本号
+Release.bat                  REM 默认：external 版，版本号 3.0.0
+Release.bat 3.1.0            REM external 版，指定版本号
 Release.bat --internal       REM internal 全功能版（保留内部 provider / 上报）
-Release.bat 2.1.0 --internal REM 组合
+Release.bat 3.1.0 --internal REM 组合
 ```
 
-产物：`dist\release\` 下的目录 + 归档；`build_info.json` 自报版本和 edition。
+产物：`.build\release\` 下的目录 + 归档；`build_info.json` 自报版本和 edition。
 
 **用户机器上的安装流程**（参考——这是发布包发给终端用户后他们要做的）：
 
@@ -132,10 +108,9 @@ Release.bat 2.1.0 --internal REM 组合
 | 改了前端依赖 (`package.json`) | `Build.bat --install` |
 | `node_modules` 坏了 | `Build.bat --clean` |
 | 写贡献者测试 / 跑 pytest | `Setup.bat --dev` 一次，之后 `Console.bat` 进 venv 跑测试 |
-| 想要桌面 App | `Setup.bat --desktop` + `Build.bat --desktop` |
 | 打发布包给用户 | `Release.bat [版本号]` |
 | 一次性敲 CLI 命令 | `qai.bat <args>` |
 | 装额外 Python 包临时试试 | `Console.bat` 进 venv，`pip install <pkg>` |
 | 彻底清理（保留 `data/`） | `Uninstall.bat`（或 `--all` 更深度） |
 
-> **任何脚本都支持 `--help` / `-h` / `/?`**，例如 `Build.bat --help` 看全部开关。
+> **`Setup.bat` / `Build.bat` / `Uninstall.bat` 支持 `--help` / `-h` / `/?`** ——例如 `Build.bat --help` 看全部开关。`Release.bat` 支持 `--help` 和 `/?`。`Start.bat` / `qai.bat` 会将额外参数透传给底层 Python 入口。


### PR DESCRIPTION
Simplify and tighten the Quick Start docs (en/zh-CN) for clarity.

Follow-up to PR #150 - the QUICK-START files were updated after the merge.