### PR TITLE
fix(ci): recurse to find Genie overlay ABI dirs in setup-qnn-sdk

### DIFF
--- a/.github/actions/setup-qnn-sdk/action.yml
+++ b/.github/actions/setup-qnn-sdk/action.yml
@@ -253,21 +253,22 @@ runs:
         $stage = "${{ steps.genie-vars-windows.outputs.stage-dir }}"
         $sdk   = $env:QNN_SDK_ROOT
 
-        # The overlay zip extracts as either:  <stage>/QAIRT_Runtime_*/...  or
-        # directly  <stage>/arm64x-windows-msvc/...  Probe for it.
+        # The ABI dirs (arm64x-windows-msvc / aarch64-windows-msvc) can sit at
+        # varying depths depending on the zip:
+        #   <stage>/arm64x-windows-msvc/...            (flat)
+        #   <stage>/QAIRT_Runtime_*/arm64x-.../...     (one level)
+        #   <stage>/QAIRT_v*/lib/arm64x-.../...        (two levels, current
+        #                                               v2.48.40 / v2.47.0 zips)
+        # A fixed 1-2 level probe silently missed the `lib/` layer, so the
+        # overlay was skipped and the build shipped the SDK's upstream Genie
+        # (wrong-ABI Genie.dll in the x64/ARM64EC wheel). Search recursively for
+        # either ABI dir and take its parent as the overlay root.
         $overlayRoot = $null
-        if ((Test-Path (Join-Path $stage "arm64x-windows-msvc")) -or
-            (Test-Path (Join-Path $stage "aarch64-windows-msvc"))) {
-          $overlayRoot = $stage
-        } else {
-          Get-ChildItem $stage -Directory | ForEach-Object {
-            if (-not $overlayRoot -and (
-                (Test-Path (Join-Path $_.FullName "arm64x-windows-msvc")) -or
-                (Test-Path (Join-Path $_.FullName "aarch64-windows-msvc"))
-              )) {
-              $overlayRoot = $_.FullName
-            }
-          }
+        $abiDir = Get-ChildItem $stage -Recurse -Directory `
+                    -Include "arm64x-windows-msvc", "aarch64-windows-msvc" `
+                    -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($abiDir) {
+          $overlayRoot = $abiDir.Parent.FullName
         }
         if (-not $overlayRoot) {
           Write-Host "::warning::Genie overlay zip layout not recognized under $stage. Skipping overlay (build will use upstream Genie). Tree:"


### PR DESCRIPTION
### What

Fix the Genie overlay probe in `.github/actions/setup-qnn-sdk/action.yml` so it finds the overlay's ABI directories regardless of nesting depth.

Closes #169.

### Why

The published QAIRT overlay zips nest the ABI dirs under a `lib/` layer:

```
QAIRT_v2.48.40.260702/lib/arm64x-windows-msvc/Genie.{dll,lib}
QAIRT_v2.48.40.260702/lib/aarch64-windows-msvc/Genie.{dll,lib}
```

The old probe only checked `<stage>/<ABI>` and `<stage>/<one-subdir>/<ABI>`, so it never reached `.../lib/<ABI>`. On a miss the step logged `layout not recognized` and `exit 0`, silently skipping the overlay — the build then shipped the SDK-bundled upstream Genie.

The most visible symptom: the windows-x64 (ARM64EC) wheel bundled a pure-ARM64 `Genie.dll` while its `.pyd` / `libappbuilder.dll` are x64, so `import qai_appbuilder` crashed on load (exit 127) on a WoS device.

### Fix

Search recursively for either ABI directory and take its parent as the overlay root. Robust to the flat layout, the `QAIRT_Runtime_*/` layout, and the current `QAIRT_v*/lib/` layout.

### Verification

Ran the full matrix on my fork with this change:

- The `Setup QNN SDK` step now logs:
  ```
  Genie overlay root: ...\QAIRT_v2.48.40.260702\lib
  Genie overlay applied (2 files):
    arm64x-windows-msvc/Genie.dll
    arm64x-windows-msvc/Genie.lib
  ```
  (previously: `layout not recognized`, overlay skipped)
- Downloaded the resulting `cp313 win_arm64ec` wheel and confirmed its bundled `Genie.dll` is now PE machine `0x8664` (x64), matching the x64 `.pyd` / `libappbuilder.dll`. Before the fix it was `0xAA64` (ARM64).