### PR TITLE
GenieAPIService: add Qwen3-VL multimodal support and related gateway/model-manager improvements

### DIFF
--- a/samples/genie/c++/Service/.gitignore
+++ b/samples/genie/c++/Service/.gitignore
@@ -11,3 +11,6 @@ build-*
 __pycache__
 QAIModelBuilder
 examples/AiHubLauncher/*
+*.MD
+*.md
+tools/

--- a/samples/genie/c++/Service/examples/SampleApp/CMakeLists.txt
+++ b/samples/genie/c++/Service/examples/SampleApp/CMakeLists.txt
@@ -25,6 +25,10 @@ target_link_libraries(SampleApp PRIVATE
 )
 
 if (UNIX)
+    # Mirrors platform.cmake's LIBAPPBUILDER_ROOT/lib (qai-appbuilder repo root); that
+    # variable lives in the sibling src/GenieAPIService subdirectory scope and isn't
+    # visible here, so the equivalent relative path is spelled out directly.
+    target_link_directories(SampleApp PRIVATE ${CMAKE_SOURCE_DIR}/../../../../lib)
     set_target_properties(SampleApp PROPERTIES
             BUILD_WITH_INSTALL_RPATH TRUE
             INSTALL_RPATH "$ORIGIN"

--- a/samples/genie/c++/Service/scripts/Android.mk
+++ b/samples/genie/c++/Service/scripts/Android.mk
@@ -55,6 +55,7 @@ SERVICE_SRC_FILES :=            ../src/GenieAPIService/src/chat_history/chat_his
                                     ../src/GenieAPIService/src/context/qnn/phi4mm/phi4mm.cpp \
                                     ../src/GenieAPIService/src/context/qnn/qwen2_5/qwen_2_5.cpp \
                                     ../src/GenieAPIService/src/context/qnn/qwen2_5_omini/qwen_2_5_omini.cpp \
+                                    ../src/GenieAPIService/src/context/qnn/qwen3_vl/qwen_3_vl.cpp \
                                     ../src/GenieAPIService/src/model/model_manager.cpp \
                                     ../src/GenieAPIService/src/port_available.cpp \
                                     ../src/GenieAPIService/src/processor/harmony.cpp \

--- a/samples/genie/c++/Service/src/GenieAPIService/CMakeLists.txt
+++ b/samples/genie/c++/Service/src/GenieAPIService/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SERVICE_SOURCES
         src/context/qnn/phi4mm/phi4mm.cpp
         src/context/qnn/qwen2_5/qwen_2_5.cpp
         src/context/qnn/qwen2_5_omini/qwen_2_5_omini.cpp
+        src/context/qnn/qwen3_vl/qwen_3_vl.cpp
         src/context/context_base.cpp
         src/GenieAPIService.cpp
         src/port_available.cpp

--- a/samples/genie/c++/Service/src/GenieAPIService/src/chat_request_handler/long_text_summarizer.cpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/chat_request_handler/long_text_summarizer.cpp
@@ -450,7 +450,7 @@ std::string LongTextSummarizer::BuildMapPrompt(const std::string& chunk,
         // 最小推理 prompt 结构（无历史消息）：
         //   str_replace(system, "string", instruction + "/no_think")  ← 禁止思考
         //   + str_replace(user,   "string", task_str)
-        //   + start + FILL_THINK  ← 注入空 think 块，与主推理保持一致
+        //   + start  （不预填空 think 块：真机实测该预填内容会导致 qwen3 在极短文本下退化）
         const auto& j = instance_config_.get_prompt_template();
 
         if (j.is_object()
@@ -458,8 +458,9 @@ std::string LongTextSummarizer::BuildMapPrompt(const std::string& chunk,
                 && j.contains("user")   && j["user"].is_string()
                 && j.contains("start")  && j["start"].is_string())
         {
-            // 若为 thinking 模型，追加 /no_think 并注入空 think 块，避免模型进入思考模式
-            // 思考模式会大幅增加摘要推理耗时，且摘要任务不需要深度推理
+            // 若为 thinking 模型，追加 /no_think 避免模型进入思考模式
+            // 思考模式会大幅增加摘要推理耗时，且摘要任务不需要深度推理；
+            // 注意：不在 start 里预填空 think 块（真机实测确认该预填内容会导致 qwen3 在极短文本下退化）
             std::string system_instruction =
                 "You are a compression assistant. Your task is to summarize content accurately.";
             std::string start_str = j["start"].get<std::string>();
@@ -467,7 +468,6 @@ std::string LongTextSummarizer::BuildMapPrompt(const std::string& chunk,
             if (instance_config_.is_thinking_model())
             {
                 system_instruction += "/no_think";
-                start_str += "<think>\n\n</think>\n\n";
             }
 
             return str_replace(j["system"].get<std::string>(), "string", system_instruction)
@@ -525,7 +525,6 @@ std::string LongTextSummarizer::BuildReducePrompt(const std::string& combined_su
             if (instance_config_.is_thinking_model())
             {
                 system_instruction += "/no_think";
-                start_str += "<think>\n\n</think>\n\n";
             }
 
             return str_replace(j["system"].get<std::string>(), "string", system_instruction)

--- a/samples/genie/c++/Service/src/GenieAPIService/src/chat_request_handler/model_input_builder.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/chat_request_handler/model_input_builder.h
@@ -326,7 +326,6 @@ private:
 
         std::string userToolsPrompt = "";
         std::string systemDefaultPrompt = "You are a helpful assistant.";
-        std::string startDefaultPrompt;
 
         My_Log{My_Log::Level::kDebug} << "[Context] Window size: " << instance_config_->get_context_size() << " tokens" << std::endl;
 
@@ -407,7 +406,9 @@ private:
         // 必须在 PreFilterMessages 之前追加 /think 或 /no_think，
         // 确保两阶段（PreFilterMessages 和 FitMessagesToContext）使用相同的 system prompt 进行 token 计算。
         // 按需求：只要当前模型是 instance_config_->is_thinking_model()，无论主推理还是其它场景，
-        // 都必须统一追加 /think 或 /no_think；当关闭 thinking 时，还必须同时注入 FILL_THINK。
+        // 都必须统一追加 /think 或 /no_think。
+        // 注意：关闭 thinking 时不再注入 FILL_THINK 预填空 think 块——真机实测确认该预填内容会导致
+        // qwen3 系列模型在极短用户提问下退化（原样复述上一轮对话后立即结束），/no_think 单独即可正确抑制思考。
         if (instance_config_->is_thinking_model())
         {
             if (instance_config_->getenableThinking())
@@ -417,7 +418,6 @@ private:
             else
             {
                 systemDefaultPrompt += "/no_think";
-                startDefaultPrompt += FILL_THINK;
             }
         }
 
@@ -508,7 +508,7 @@ private:
 
         std::string modelInputContent = chat_history_.GetUserMessage(
                                                           str_replace(j["system"], "string", systemDefaultPrompt),
-                                                          j["start"].get<std::string>() + startDefaultPrompt);
+                                                          j["start"].get<std::string>());
 
         // 计算最终提示词的真实 token 数
         // 修复：使用注入的 context_（多模型并发安全），而非 model_config_.get_genie_model_handle()
@@ -1721,8 +1721,6 @@ private:
         model_input_.agent_type_ = "sub";  // 默认为子 Agent，由 Build() 中检测后覆盖
         tool_call_id_to_name_.clear();
     }
-
-    static inline const std::string FILL_THINK = "<think>\n\n</think>\n\n";
 
     static inline const std::string BLANK_STRING;
 

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/genie_interface.cpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/genie_interface.cpp
@@ -24,6 +24,7 @@ void IEmbedding::TokenToEmbedCallback<float, float>(int32_t token,
 #include "phi4mm/phi4mm.h"
 #include "qwen2_5/qwen_2_5.h"
 #include "qwen2_5_omini/qwen_2_5_omini.h"
+#include "qwen3_vl/qwen_3_vl.h"
 
 IEmbedding::IEmbedding(GenieContext *context) :
         QInterface(context),
@@ -78,6 +79,8 @@ IEmbedding *IEmbedding::CreateInterface(GenieContext *context)
             return new Qwen2_5(context);
         case QNNEmbeddingType::QWEN2_5_OMINI:
             return new Qwen2_5OMINI(context);
+        case QNNEmbeddingType::QWEN3_VL:
+            return new Qwen3VL(context);
     }
     return nullptr;
 }
@@ -195,6 +198,13 @@ Genie_Status_t QInterfaceImpl::IEmbedding::GenieDialogQueryImpl()
                                          token_to_embed_callback_fn_,
                                          GenieCallBack,
                                          this);
+    if (context_->model_config_.i_model_config_.get_qnn_embedding().embedding_type_ == QNNEmbeddingType::QWEN3_VL)
+    {
+        My_Log("[Qwen3VL DIAG] GenieDialog_embeddingQuery returned rs=" + std::to_string(int(rs))
+               + " input_len_=" + std::to_string(input_len_)
+               + " stream_answer_len=" + std::to_string(context_->m_stream_answer.size()),
+               My_Log::Level::kWarning);
+    }
     return rs;
 }
 
@@ -249,6 +259,51 @@ IEmbedding &IEmbedding::BuildInferredBuffer(const QNNEmbedding::InferResource *i
         }
         inferred_buffers[i].assign(outputBuffers.at(0), outputBuffers.at(0) + outputSize.at(0));
         free(outputBuffers[0]);
+        outputSize.clear();
+        outputBuffers.clear();
+    }
+    return *this;
+}
+
+IEmbedding &IEmbedding::BuildInferredBuffer(const QNNEmbedding::InferResource *infer_resource,
+                                            std::vector<std::vector<uint8_t *>> &input_buffers,
+                                            std::vector<std::vector<uint8_t>> &inferred_buffers,
+                                            std::vector<std::vector<uint8_t>> &extra_outputs)
+{
+    static std::string perfProfile = "burst";
+    auto app_builder = infer_resource->app_builder_;
+    std::vector<uint8_t *> outputBuffers;
+    std::vector<size_t> outputSize;
+
+    inferred_buffers.resize(input_buffers.size());
+    extra_outputs.clear();
+    for (auto i = 0; i < input_buffers.size(); ++i)
+    {
+        if (!app_builder->ModelInference(infer_resource->tag_,
+                                         input_buffers[i],
+                                         outputBuffers,
+                                         outputSize,
+                                         perfProfile))
+        {
+            throw std::runtime_error("call model inference failed");
+        }
+        std::string output_sizes_str;
+        for (auto sz : outputSize)
+        {
+            output_sizes_str += std::to_string(sz) + " ";
+        }
+        My_Log("[Qwen3VL DIAG] vision encoder returned " + std::to_string(outputBuffers.size())
+               + " output buffer(s), sizes: " + output_sizes_str, My_Log::Level::kWarning);
+
+        inferred_buffers[i].assign(outputBuffers.at(0), outputBuffers.at(0) + outputSize.at(0));
+        for (size_t k = 1; k < outputBuffers.size(); ++k)
+        {
+            extra_outputs.emplace_back(outputBuffers[k], outputBuffers[k] + outputSize[k]);
+        }
+        for (auto *buf : outputBuffers)
+        {
+            free(buf);
+        }
         outputSize.clear();
         outputBuffers.clear();
     }

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/genie_interface.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/genie_interface.h
@@ -71,6 +71,8 @@ struct GenieContext::QInterfaceImpl
 
         class Qwen2_5OMINI;
 
+        class Qwen3VL;
+
     protected:
         GenieContext *context_;
         uint8_t *input_data_{};
@@ -162,6 +164,14 @@ struct GenieContext::QInterfaceImpl
         IEmbedding &BuildInferredBuffer(const QNNEmbedding::InferResource *infer_resource,
                                         std::vector<std::vector<uint8_t *>> &input_buffers,
                                         std::vector<std::vector<uint8_t>> &inferred_buf);
+
+        // Qwen3VL 专用重载：除主输出（保存进 inferred_buf，行为与上面重载一致）外，
+        // 把其余输出缓冲区也拷贝进 extra_outputs 并统一 free 掉，避免只取
+        // outputBuffers[0] 导致额外输出（如 deepstack 特征）被丢弃且内存泄漏。
+        IEmbedding &BuildInferredBuffer(const QNNEmbedding::InferResource *infer_resource,
+                                        std::vector<std::vector<uint8_t *>> &input_buffers,
+                                        std::vector<std::vector<uint8_t>> &inferred_buf,
+                                        std::vector<std::vector<uint8_t>> &extra_outputs);
 
         virtual IEmbedding &CustomBuild(ModelInput &model_input) = 0;
 

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen3_vl_image_processor.hpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen3_vl_image_processor.hpp
@@ -1,0 +1,335 @@
+//==============================================================================
+//
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+//==============================================================================
+
+#pragma once
+/*
+ * qwen3_vl_image_processor.hpp
+ *
+ * 封装：float全流程解码图片 → Alpha白底合成(float空间) → smart_resize(按32对齐) →
+ *      float缩放 → patch展开并归一化到[-1,1] → 写出buffer
+ * 说明：
+ *  1) 依赖 stb_image / stb_image_resize2（头文件实现库），STB_IMAGE_IMPLEMENTATION /
+ *     STB_IMAGE_RESIZE2_IMPLEMENTATION 已由 phi4mm.cpp 在同一链接目标内定义一次，
+ *     本文件不重复定义。
+ *  2) 图像解码/缩放全程走 float 通道（同 phi4mm.cpp 的 stbi_loadf + stbir_quick_resize_helper
+ *     流水线），避免"先转 uint8 再手动归一化"引入的二次量化损失。
+ *  3) patchify 展平顺序（外层 ho,wo,mh,mw；内层 c,t,ph,pw）与 qwen25_image_processor.hpp
+ *     一致（数学公式同源，仅 PATCH_SIZE/MEAN/STD/对齐因子不同）。
+ */
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <stb_image.h>
+#include <stb_image_resize2.h>
+
+namespace qwen3_vl
+{
+    class Qwen3VLImageProcessor
+    {
+    public:
+        // --- 常量：与 Qwen3-VL preprocessor_config.json / vision_config 一致 ---
+        static constexpr int PATCH_SIZE = 16;
+        static constexpr int TEMPORAL_PATCH_SIZE = 2;
+        static constexpr int MERGE_SIZE = 2;
+        static constexpr int SPATIAL_MERGE_SIZE = 2;
+        static constexpr int PATCH_FACTOR = PATCH_SIZE * SPATIAL_MERGE_SIZE; // =32，对齐因子
+
+        // 纯线性映射到[-1,1]（与 CLIP mean/std 不同）
+        static constexpr float MEAN[3] = {0.5f, 0.5f, 0.5f};
+        static constexpr float STD[3] = {0.5f, 0.5f, 0.5f};
+
+        // 用于承载 float [0,1] 空间的 RGB(A) 图像
+        struct ImageF32
+        {
+            int w = 0, h = 0, c = 0; // c=3或4
+            std::vector<float> data; // 行主序，交错排列
+        };
+
+    public:
+        Qwen3VLImageProcessor() = default;
+
+        void ProcessToBuffer(uint8_t *png_bin_buf,
+                             unsigned long dwLen,
+                             int request_h,
+                             int request_w,
+                             std::vector<float> &out,
+                             int &rows, int &cols) const
+        {
+            ImageF32 img = LoadImageF32_STB(png_bin_buf, dwLen);
+            ImageF32 rgb = ToRGBWhiteBackground(img);
+            auto [rh, rw] = smart_resize(request_h, request_w, PATCH_FACTOR);
+            ImageF32 rgb_resized = ResizeRGB_STB(rgb, rw, rh);
+            GeneratePixelValuesToBuffer(rgb_resized, out, rows, cols);
+        }
+
+        // 仅计算 smart_resize 的结果尺寸（便于调用方预估）
+        static std::pair<int, int> SmartResizeOnly(int request_h, int request_w)
+        {
+            return smart_resize(request_h, request_w, PATCH_FACTOR);
+        }
+
+    private:
+        // --- 工具函数（与 qwen25_image_processor.hpp 相同的数学公式，仅对齐因子不同） ---
+        static inline int round_by_factor(double number, int factor)
+        {
+            return static_cast<int>(std::llround(number / factor) * factor);
+        }
+
+        static inline int ceil_by_factor(double number, int factor)
+        {
+            return static_cast<int>(std::ceil(number / factor) * factor);
+        }
+
+        static inline int floor_by_factor(double number, int factor)
+        {
+            return static_cast<int>(std::floor(number / factor) * factor);
+        }
+
+        static std::pair<int, int> smart_resize_impl(
+                int height, int width, int factor,
+                int min_pixels, int max_pixels)
+        {
+            const double max_ratio = 200.0;
+            if (static_cast<double>(std::max(height, width)) / std::min(height, width) > max_ratio)
+            {
+                throw std::runtime_error("aspect ratio too large");
+            }
+
+            int h_bar = std::max(factor, round_by_factor(height, factor));
+            int w_bar = std::max(factor, round_by_factor(width, factor));
+            long long area = 1LL * h_bar * w_bar;
+
+            if (area > max_pixels)
+            {
+                double beta = std::sqrt((static_cast<double>(height) * width) / max_pixels);
+                h_bar = floor_by_factor(height / beta, factor);
+                w_bar = floor_by_factor(width / beta, factor);
+            }
+            else
+                if (area < min_pixels)
+                {
+                    double beta =
+                            std::sqrt(static_cast<double>(min_pixels) / (static_cast<double>(height) * width));
+                    h_bar = ceil_by_factor(height * beta, factor);
+                    w_bar = ceil_by_factor(width * beta, factor);
+                }
+            return {h_bar, w_bar};
+        }
+
+        static inline std::pair<int, int> smart_resize(int height, int width, int factor)
+        {
+            const int min_pixels = 65536;
+            const int max_pixels = 16777216;
+            return smart_resize_impl(height, width, factor, min_pixels, max_pixels);
+        }
+
+        // 解码为 float [0,1] 像素：stbi_ldr_to_hdr_gamma(1.0f) 关闭默认 gamma 变换
+        // （与 phi4mm.cpp 的 float 解码流水线一致），仅在这一次解码期间临时切换该全局状态。
+        static ImageF32 LoadImageF32_STB(uint8_t *buf, unsigned long dwLen)
+        {
+            stbi_ldr_to_hdr_gamma(1.0f);
+            int w = 0, h = 0, n = 0;
+            float *pixels = stbi_loadf_from_memory(buf, dwLen, &w, &h, &n, 0);
+            stbi_ldr_to_hdr_gamma(2.2f);
+            if (!pixels) { throw std::runtime_error("stb_image: failed to decode image"); }
+
+            ImageF32 out;
+            if (n == 3)
+            {
+                out.w = w;
+                out.h = h;
+                out.c = 3;
+                out.data.assign(pixels, pixels + static_cast<size_t>(w) * h * 3);
+            }
+            else
+                if (n == 4)
+                {
+                    out.w = w;
+                    out.h = h;
+                    out.c = 4;
+                    out.data.assign(pixels, pixels + static_cast<size_t>(w) * h * 4);
+                }
+                else
+                    if (n == 1)
+                    {
+                        // 灰度 → RGB
+                        out.w = w;
+                        out.h = h;
+                        out.c = 3;
+                        out.data.resize(static_cast<size_t>(w) * h * 3);
+                        for (size_t i = 0; i < static_cast<size_t>(w) * h; ++i)
+                        {
+                            float g = pixels[i];
+                            out.data[i * 3 + 0] = g;
+                            out.data[i * 3 + 1] = g;
+                            out.data[i * 3 + 2] = g;
+                        }
+                    }
+                    else
+                        if (n == 2)
+                        {
+                            // 灰度+Alpha → RGBA
+                            out.w = w;
+                            out.h = h;
+                            out.c = 4;
+                            out.data.resize(static_cast<size_t>(w) * h * 4);
+                            for (size_t i = 0; i < static_cast<size_t>(w) * h; ++i)
+                            {
+                                float g = pixels[i * 2 + 0];
+                                float a = pixels[i * 2 + 1];
+                                out.data[i * 4 + 0] = g;
+                                out.data[i * 4 + 1] = g;
+                                out.data[i * 4 + 2] = g;
+                                out.data[i * 4 + 3] = a;
+                            }
+                        }
+                        else
+                        {
+                            stbi_image_free(pixels);
+                            throw std::runtime_error("Unsupported channel count from stb_image");
+                        }
+            stbi_image_free(pixels);
+            return out;
+        }
+
+        // RGBA → RGB 的白底合成（float [0,1] 空间）：c=3直接返回，c=4执行 alpha over 白色。
+        static ImageF32 ToRGBWhiteBackground(const ImageF32 &in)
+        {
+            if (in.c == 3) return in;
+            if (in.c != 4) throw std::runtime_error("ToRGBWhiteBackground: unsupported channels");
+
+            ImageF32 out;
+            out.w = in.w;
+            out.h = in.h;
+            out.c = 3;
+            out.data.resize(static_cast<size_t>(out.w) * out.h * 3);
+            for (int i = 0; i < in.w * in.h; ++i)
+            {
+                float r = in.data[i * 4 + 0];
+                float g = in.data[i * 4 + 1];
+                float b = in.data[i * 4 + 2];
+                float a = in.data[i * 4 + 3];
+                out.data[i * 3 + 0] = r * a + 1.0f * (1.0f - a);
+                out.data[i * 3 + 1] = g * a + 1.0f * (1.0f - a);
+                out.data[i * 3 + 2] = b * a + 1.0f * (1.0f - a);
+            }
+            return out;
+        }
+
+        // 使用 stb_image_resize2 的 medium api（stbir_resize，跨编译单元可用，不依赖实现宏）
+        // 进行缩放（float RGB）。注意：必须用 STBIR_FILTER_CATMULLROM，不能用 STBIR_FILTER_MITCHELL
+        // —— 在特定放大比例下会导致 stb 库内部越界访问，必现崩溃（Phi4-mm 已踩过的坑）。
+        static ImageF32 ResizeRGB_STB(const ImageF32 &in, int out_w, int out_h)
+        {
+            if (in.c != 3) throw std::runtime_error("ResizeRGB_STB expects RGB input");
+            ImageF32 out;
+            out.w = out_w;
+            out.h = out_h;
+            out.c = 3;
+            out.data.resize(static_cast<size_t>(out_w) * out_h * 3);
+
+            if (!stbir_resize(
+                    in.data.data(), in.w, in.h, 0,
+                    out.data.data(), out_w, out_h, 0,
+                    STBIR_RGB, STBIR_TYPE_FLOAT, STBIR_EDGE_REFLECT, STBIR_FILTER_CATMULLROM))
+            {
+                throw std::runtime_error("stb_image_resize: resize failed");
+            }
+            return out;
+        }
+
+        // 生成 pixel_values（float32）：patchify 展平顺序与 qwen25_image_processor.hpp 一致
+        // （外层 ho,wo,mh,mw；内层 c,t,ph,pw），仅 patch_size 与归一化公式不同。
+        static void GeneratePixelValuesToBuffer(const ImageF32 &rgb,
+                                                std::vector<float> &out,
+                                                int &rows, int &cols)
+        {
+            assert(rgb.c == 3);
+            const int H = rgb.h;
+            const int W = rgb.w;
+            if (H % PATCH_SIZE != 0 || W % PATCH_SIZE != 0)
+            {
+                throw std::runtime_error("H/W not divisible by patch_size");
+            }
+
+            const int grid_h = H / PATCH_SIZE;
+            const int grid_w = W / PATCH_SIZE;
+            const int grid_h_outer = grid_h / MERGE_SIZE;
+            const int grid_w_outer = grid_w / MERGE_SIZE;
+            const int T = TEMPORAL_PATCH_SIZE;
+
+            // 归一化并复制到两个时间帧（t=0与t=1相同），像素已是 float [0,1]，无需再除以255。
+            std::vector<float> norm(static_cast<size_t>(T) * 3 * static_cast<size_t>(H) * static_cast<size_t>(W));
+            auto idx4 = [&](int t, int c, int y, int x)
+            {
+                return (static_cast<size_t>(t) * 3 + c) * static_cast<size_t>(H) * static_cast<size_t>(W)
+                       + static_cast<size_t>(y) * static_cast<size_t>(W) + static_cast<size_t>(x);
+            };
+            for (int y = 0; y < H; ++y)
+            {
+                for (int x = 0; x < W; ++x)
+                {
+                    const float *p = &rgb.data[(y * W + x) * 3];
+                    for (int c = 0; c < 3; ++c)
+                    {
+                        float v = (p[c] - MEAN[c]) / STD[c];
+                        norm[idx4(0, c, y, x)] = v;
+                        norm[idx4(1, c, y, x)] = v;
+                    }
+                }
+            }
+
+            // 展平顺序：外层 ho, wo, mh, mw；内层 c, t, ph, pw —— 与qwen25_image_processor.hpp一致。
+            rows = 1 * grid_h * grid_w; // grid_t=1
+            cols = 3 * T * PATCH_SIZE * PATCH_SIZE;
+            out.assign(static_cast<size_t>(rows) * cols, 0.0f);
+
+            int r = 0;
+            for (int ho = 0; ho < grid_h_outer; ++ho)
+            {
+                for (int wo = 0; wo < grid_w_outer; ++wo)
+                {
+                    for (int mh = 0; mh < MERGE_SIZE; ++mh)
+                    {
+                        for (int mw = 0; mw < MERGE_SIZE; ++mw)
+                        {
+                            int py0 = (ho * MERGE_SIZE + mh) * PATCH_SIZE;
+                            int px0 = (wo * MERGE_SIZE + mw) * PATCH_SIZE;
+
+                            int k = 0;
+                            for (int c = 0; c < 3; ++c)
+                            {
+                                for (int t = 0; t < T; ++t)
+                                {
+                                    for (int ph = 0; ph < PATCH_SIZE; ++ph)
+                                    {
+                                        for (int pw = 0; pw < PATCH_SIZE; ++pw)
+                                        {
+                                            out[static_cast<size_t>(r) * cols + k] =
+                                                    norm[idx4(t, c, py0 + ph,
+                                                              px0 + pw)];
+                                            ++k;
+                                        }
+                                    }
+                                }
+                            }
+                            ++r;
+                        }
+                    }
+                }
+            }
+            assert(r == rows);
+        }
+    };
+}

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen_3_vl.cpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen_3_vl.cpp
@@ -1,0 +1,89 @@
+//==============================================================================
+//
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+//==============================================================================
+
+#include <stb_image.h>
+#include <stb_image_resize2.h>
+
+#include "qwen_3_vl.h"
+#include "qwen3_vl_image_processor.hpp"
+#include "../../torch_helper/masked_scatter.h"
+#include <log.h>
+
+IVisionEmbedding &QInterface::Qwen3VL::BuildImgPixel()
+{
+    using namespace qwen3_vl;
+    int rows = 0, cols = 0;
+    Qwen3VLImageProcessor proc;
+    proc.ProcessToBuffer(img_buf_.data(), img_buf_.size(), kHeight, kWidth, img_pixel_buf_, rows, cols);
+    img_buf_.clear();
+    return *this;
+}
+
+IEmbedding &QInterface::Qwen3VL::CustomBuild(ModelInput &model_input)
+{
+    dynamic_cast<IVisionEmbedding &>(Decode(model_input.image_, img_buf_))
+            .BuildImgPixel()
+            .PaddingVisionPrompt()
+            .BuildVisionInferredInput();
+    // BuildInferredBuffer() 是 IEmbedding 的 protected 成员，IEmbedding 又是
+    // IVisionEmbedding 的虚基类；不能通过上面链式调用返回的 IVisionEmbedding&
+    // 访问它（C++ 虚基类保护成员访问规则），必须通过 this（Qwen3VL*）单独调用。
+    BuildInferredBuffer(infer_resource_, input_buffers_, img_inferred_buffers_, deepstack_buffers_);
+    return *this;
+}
+
+IVisionEmbedding &QInterface::Qwen3VL::MergeEmbedding()
+{
+    static const int32_t image_token_id{151655};
+    const unsigned long token_count = prompt_token_size_;
+    BufferView<float> tmp_raw_fbuf{qnn_embedding_info_.embedded_raw_buf_};
+
+    std::vector<float> embedded_raw_fbuf;
+    embedded_raw_fbuf.resize(token_count * cols_);
+    float *dest_ptr;
+    for (uint32_t i = 0; i < prompt_token_size_; ++i)
+    {
+        dest_ptr = &embedded_raw_fbuf[i * cols_];
+        float *src_ptr = &tmp_raw_fbuf.pointer_[prompt_token_[i] * cols_];
+        std::memcpy(dest_ptr, src_ptr, cols_ * sizeof(float));
+    }
+
+    if (img_inferred_buffers_.empty())
+    {
+        embedded_bin_ = std::move(embedded_raw_fbuf);
+        input_data_ = reinterpret_cast<uint8_t*>(embedded_bin_.data());
+        input_len_ = embedded_bin_.size() * sizeof(float);
+        return *this;
+    }
+
+    BufferView<float> img_embedding_fbuf{img_inferred_buffers_[0]};
+    std::vector<size_t> image_rows;
+    torch_helper::MaskedScatterMergeEmbedding(prompt_token_, token_count, image_token_id,
+                                              embedded_raw_fbuf, img_embedding_fbuf, embedded_bin_, &image_rows);
+
+    // GenieDialog/GenieNode 均不支持向已编译好的解码器中间层注入具名张量（见
+    // qwen3_vl.md），embeddingQuery 唯一可控的通道是这段扁平输入 embedding；
+    // 因此把 3 层 deepstack 残差近似折算进 image_rows 对应的行再一次性传入。
+    if (!deepstack_buffers_.empty())
+    {
+        std::vector<BufferView<float>> deepstack_fbufs;
+        deepstack_fbufs.reserve(deepstack_buffers_.size());
+        for (auto &buf: deepstack_buffers_)
+        {
+            deepstack_fbufs.emplace_back(buf);
+        }
+        torch_helper::AddDeepstackResidual(image_rows, static_cast<size_t>(cols_), deepstack_fbufs, embedded_bin_);
+        My_Log("[Qwen3VL DIAG] folded " + std::to_string(deepstack_buffers_.size())
+               + " deepstack buffer(s) additively into " + std::to_string(image_rows.size())
+               + " image row(s) before embeddingQuery.", My_Log::Level::kWarning);
+    }
+
+    input_data_ = reinterpret_cast<uint8_t*>(embedded_bin_.data());
+    input_len_ = embedded_bin_.size() * sizeof(float);
+    return *this;
+}

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen_3_vl.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/qnn/qwen3_vl/qwen_3_vl.h
@@ -1,0 +1,72 @@
+//==============================================================================
+//
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+//==============================================================================
+
+#ifndef QWEN_3_VL_H
+#define QWEN_3_VL_H
+
+#include "../genie_interface.h"
+#include "utils.h"
+
+class QInterface::Qwen3VL : public IVisionEmbedding
+{
+public:
+    explicit Qwen3VL(GenieContext *context) : IVisionEmbedding(context), IEmbedding(context)
+    {
+        kPromptTemplate = "<|im_start|>system\n"
+                          "%s.<|im_end|>\n"
+                          "<|im_start|>user\n%s"
+                          "%s"  //<|vision_start|><|image_pad|><|vision_end|>
+                          "<|im_end|>\n"
+                          "<|im_start|>assistant\n";
+
+        kPaddedList_ = "<|vision_start|><|image_pad|><|vision_end|>";
+
+        // 图像尺寸/patch/merge 参数在 4B、8B 上完全一致（均为 512x512），
+        // 仅 HIDDEN_SIZE（=VISION_OUT_HIDDEN_SIZE）随模型规模变化，见
+        // ai-hub-models qwen3_vl_{4b,8b}_instruct/model.py 的架构常量对比。
+        kHeight = kWidth = 512;
+
+        auto &name = context->model_config_.get_model_name();
+        if (str_contains(name, "8b"))
+        {
+            cols_ = 4096;
+        }
+        else if (str_contains(name, "4b"))
+        {
+            cols_ = 2560;
+        }
+        else
+        {
+            throw std::runtime_error("Qwen3VL not match rules of 4b or 8b");
+        }
+
+        token_to_embed_callback_fn_ = &TokenToEmbedCallback<float, float>;
+    }
+
+    IVisionEmbedding &BuildImgPixel() final;
+
+    // 真机实测（vision_encoder.bin 图要求 Expected: 5 个输入，见 qwen3_vl.md）证实
+    // get_visual_input_names() 里的 "mask" 并不是真实导出图的独立输入；这里仍覆写
+    // CustomBuild() 只是为了改用能捕获额外输出（deepstack_buffers_）的 4 参
+    // BuildInferredBuffer() 重载，流程与基类 IVisionEmbedding::CustomBuild() 完全一致。
+    IEmbedding &CustomBuild(ModelInput &model_input) override;
+
+    IVisionEmbedding &MergeEmbedding() override;
+
+    IVisionEmbedding &CleanVision() override
+    {
+        embedded_bin_.clear();
+        deepstack_buffers_.clear();
+        return *this;
+    }
+
+    std::vector<float> embedded_bin_;
+    std::vector<std::vector<uint8_t>> deepstack_buffers_;
+};
+
+#endif //QWEN_3_VL_H

--- a/samples/genie/c++/Service/src/GenieAPIService/src/context/torch_helper/masked_scatter.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/context/torch_helper/masked_scatter.h
@@ -1,0 +1,191 @@
+//==============================================================================
+//
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+//==============================================================================
+
+#ifndef MASKED_SCATTER_H
+#define MASKED_SCATTER_H
+/*
+ * masked_scatter.h
+ *
+ * 从 Qwen2_5::MergeEmbedding() 抽取的通用逻辑：按 image_token_id 在 prompt_token 中出现的
+ * 位置，把视觉 encoder 输出的 embedding 合并进文本 embedding 序列，支持两种分支
+ * （与原实现完全一致，行为未做任何改写）：
+ *  1) 图像 token 数量与视觉特征条目数量精确匹配：逐行直接替换。
+ *  2) 仅存在 1 个占位 token：展开为 N 个连续的 image_token_id，并对 embedding 做 slice+concat。
+ * 仅供 Qwen3VL 调用，qwen_2_5.cpp/h 保持原样不做任何改动。
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "base.h"
+
+namespace torch_helper
+{
+    template<typename T>
+    void MaskedScatterMergeEmbedding(const int32_t *prompt_token,
+                                     size_t token_count,
+                                     int32_t image_token_id,
+                                     const std::vector<T> &embedded_raw_fbuf,
+                                     const BufferView<T> &img_embedding_fbuf,
+                                     std::vector<T> &embedded_bin,
+                                     std::vector<size_t> *out_image_rows = nullptr)
+    {
+        size_t n_image_tokens = 0;
+        for (size_t i = 0; i < token_count; ++i)
+        {
+            if (prompt_token[i] == image_token_id)
+            {
+                ++n_image_tokens;
+            }
+        }
+
+        if (embedded_raw_fbuf.size() % token_count != 0)
+        {
+            throw std::runtime_error(std::string{"embeddings raw buf length is not divisible by sequence length, "}
+                                     + "embedded_raw_fbuf.size_: " + std::to_string(embedded_raw_fbuf.size()) + " "
+                                     + "num_tokens: " + std::to_string(token_count));
+        }
+        const size_t D = embedded_raw_fbuf.size() / token_count;
+        if (img_embedding_fbuf.size_ % D != 0)
+        {
+            throw std::runtime_error("image embeds buf length is not divisible by embed dim D");
+        }
+        const size_t N_feat = img_embedding_fbuf.size_ / D;
+
+        if (n_image_tokens != N_feat)
+        {
+            if (n_image_tokens != 1 || n_image_tokens == 0)
+            {
+                throw std::runtime_error("expected exactly 1 image token placeholder for expansion");
+            }
+
+            size_t pos = token_count;
+            for (size_t i = 0; i < token_count; ++i)
+            {
+                if (prompt_token[i] == image_token_id)
+                {
+                    pos = i;
+                    break;
+                }
+            }
+            if (pos == token_count)
+            {
+                throw std::runtime_error("Image token placeholder not found");
+            }
+
+            std::vector<int32_t> new_input_ids;
+            new_input_ids.reserve(token_count - 1 + N_feat);
+            new_input_ids.insert(new_input_ids.end(), prompt_token, prompt_token + pos);
+            for (size_t k = 0; k < N_feat; ++k)
+            {
+                new_input_ids.push_back(image_token_id);
+            }
+            new_input_ids.insert(new_input_ids.end(), prompt_token + pos + 1, prompt_token + token_count);
+
+            const size_t left_count = pos * D;
+            const size_t mid_count = N_feat * D;
+
+            embedded_bin.reserve(left_count + mid_count + (token_count - pos - 1) * D);
+            embedded_bin.insert(embedded_bin.end(), embedded_raw_fbuf.data(), embedded_raw_fbuf.data() + left_count);
+            embedded_bin.insert(embedded_bin.end(), img_embedding_fbuf.pointer_, img_embedding_fbuf.pointer_ + mid_count);
+            embedded_bin.insert(embedded_bin.end(),
+                                embedded_raw_fbuf.data() + (pos + 1) * D,
+                                embedded_raw_fbuf.data() + embedded_raw_fbuf.size());
+
+            std::vector<size_t> seq_pos;
+            for (size_t i = 0; i < new_input_ids.size(); ++i)
+            {
+                if (new_input_ids[i] == image_token_id)
+                {
+                    seq_pos.push_back(i);
+                }
+            }
+            if (seq_pos.size() != N_feat)
+            {
+                throw std::runtime_error("after expansion, number of image tokens != number of image features");
+            }
+            for (size_t j = 0; j < N_feat; ++j)
+            {
+                size_t row = seq_pos[j];
+                const T *src = &img_embedding_fbuf.pointer_[j * D];
+                T *dst = &embedded_bin[row * D];
+                std::copy(src, src + D, dst);
+            }
+            if (out_image_rows)
+            {
+                *out_image_rows = std::move(seq_pos);
+            }
+        }
+        else
+        {
+            embedded_bin.assign(embedded_raw_fbuf.data(), embedded_raw_fbuf.data() + embedded_raw_fbuf.size());
+            size_t matched = 0;
+            std::vector<size_t> image_rows;
+            for (size_t i = 0; i < token_count; ++i)
+            {
+                if (prompt_token[i] == image_token_id)
+                {
+                    const T *src = &img_embedding_fbuf.pointer_[matched * D];
+                    T *dst = &embedded_bin[i * D];
+                    std::copy(src, src + D, dst);
+                    image_rows.push_back(i);
+                    ++matched;
+                    if (matched > N_feat)
+                    {
+                        throw std::runtime_error("more image tokens than features");
+                    }
+                }
+            }
+            if (matched != N_feat)
+            {
+                throw std::runtime_error("number of image tokens != number of image features");
+            }
+            if (out_image_rows)
+            {
+                *out_image_rows = std::move(image_rows);
+            }
+        }
+    }
+
+    // Qwen3-VL deepstack 近似折算：真实架构是在解码器第 0/1/2 层输出后把
+    // deepstack_visual_embeds_i 残差相加（transformers/models/qwen3_vl/modeling_qwen3_vl.py
+    // language_model() 的 deepstack_visual_embeds 参数），但当前 Genie SDK 的
+    // GenieDialog/GenieNode 接口都不支持向已编译好的解码器中间层注入具名张量
+    // （见 qwen3_vl.md），唯一可控的通道是喂给 embeddingQuery 的那一段扁平输入
+    // embedding；因此把 3 层 deepstack 特征直接累加进 image_rows 对应的行，
+    // 在进入解码器之前一次性折算进去。
+    template<typename T>
+    void AddDeepstackResidual(const std::vector<size_t> &image_rows,
+                              size_t D,
+                              const std::vector<BufferView<T>> &deepstack_fbufs,
+                              std::vector<T> &embedded_bin)
+    {
+        const size_t N_feat = image_rows.size();
+        for (const auto &fbuf: deepstack_fbufs)
+        {
+            if (fbuf.size_ != N_feat * D)
+            {
+                throw std::runtime_error("deepstack buffer size does not match image_rows * D");
+            }
+            for (size_t j = 0; j < N_feat; ++j)
+            {
+                const T *src = &fbuf.pointer_[j * D];
+                T *dst = &embedded_bin[image_rows[j] * D];
+                for (size_t k = 0; k < D; ++k)
+                {
+                    dst[k] += src[k];
+                }
+            }
+        }
+    }
+}
+
+#endif //MASKED_SCATTER_H

--- a/samples/genie/c++/Service/src/GenieAPIService/src/gateway/gateway/gateway.cpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/gateway/gateway/gateway.cpp
@@ -91,12 +91,14 @@ GenieRoutingGateway::GenieRoutingGateway(IModelConfig &model_config,
     // 测试时可通过 SetLocalAvailabilityChecker 注入返回 false 的函数，
     // 以验证 S2+本地不可用（HTTP 403）等场景。
     //
-    // 缓存本地可用性状态，避免每个请求在路由决策阶段持有全局 models_mutex_。
-    // 在当前架构下，模型在服务启动时加载，运行期间不变，因此缓存是安全的。
-    // 若未来支持运行时动态加载/卸载模型，需改用原子变量或其他无锁机制。
-    bool local_available_cached = model_config.IsLocalModelAvailable();
-    local_availability_checker_ = [local_available_cached]() -> bool {
-        return local_available_cached;  // 无锁读取缓存值
+    // 不能在构造时缓存这个值：单模型模式下若启动未带 -l（不预加载），或多模型模式下
+    // service_config.json 的模型仍在后台线程异步加载，GenieRoutingGateway 构造时
+    // IsLocalModelAvailable() 必然是 false；之后请求触发的动态加载（见
+    // ChatCompletions 里的 LoadModelByName）即使成功，缓存值也不会更新，导致路由
+    // 永远误判"本地不可用"并 fallback 到云端（实测复现为 503 all_routes_unavailable）。
+    // 每次实时调用，让路由决策反映模型的真实加载状态。
+    local_availability_checker_ = [this]() -> bool {
+        return model_config_.IsLocalModelAvailable();
     };
 
     My_Log{} << "[GenieRoutingGateway] Initialized, routing.enabled=" << routing_config.enabled

--- a/samples/genie/c++/Service/src/GenieAPIService/src/gateway/gateway/gateway.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/gateway/gateway/gateway.h
@@ -221,7 +221,7 @@ public:
     void ResolveServerSessionIds(const json &request, InspectionContext &ctx);
 
     // 设置本地可用性检测函数（用于测试注入或未来动态模型卸载场景）
-    // 默认实现：检查 model_config.get_genie_model_handle().lock() != nullptr
+    // 默认实现：实时调用 model_config_.IsLocalModelAvailable()
     // 测试时可通过注入返回 false 的函数，以验证 S2+本地不可用（HTTP 403）等场景：
     //   agent->SetLocalAvailabilityChecker([]{ return false; });
     void SetLocalAvailabilityChecker(std::function<bool()> checker);

--- a/samples/genie/c++/Service/src/GenieAPIService/src/gateway/security/security_prompt_builder.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/gateway/security/security_prompt_builder.h
@@ -68,7 +68,9 @@ inline std::string BuildLocalModelPrompt(
         return instance_config ? instance_config->get_prompt_template() : model_config->get_prompt_template();
     };
 
-    auto append_think_control = [&](std::string& system_text, std::string& start_prompt) {
+    // 注意：关闭 thinking 时不再预填空 think 块——真机实测确认该预填内容会导致
+    // qwen3 系列模型在极短用户提问下退化，/no_think 单独即可正确抑制思考。
+    auto append_think_control = [&](std::string& system_text) {
         if (!is_thinking()) {
             return;
         }
@@ -76,7 +78,6 @@ inline std::string BuildLocalModelPrompt(
             system_text += "/think";
         } else {
             system_text += "/no_think";
-            start_prompt += "<think>\n\n</think>\n\n";
         }
     };
 
@@ -105,8 +106,7 @@ inline std::string BuildLocalModelPrompt(
             knowledge_cutoff, current_date, reasoning_level, false);
 
         std::string effective_system_prompt = system_prompt;
-        std::string ignored_start_prompt;
-        append_think_control(effective_system_prompt, ignored_start_prompt);
+        append_think_control(effective_system_prompt);
 
         std::string developer_msg  = "<|start|>developer<|message|># Instructions\n\n";
         developer_msg += effective_system_prompt;
@@ -144,7 +144,7 @@ inline std::string BuildLocalModelPrompt(
 
         std::string effective_system_prompt = system_prompt;
         std::string start_prompt = j["start"].get<std::string>();
-        append_think_control(effective_system_prompt, start_prompt);
+        append_think_control(effective_system_prompt);
 
         std::string formatted_system = replace_placeholder(j["system"].get<std::string>(), effective_system_prompt);
         std::string formatted_user   = replace_placeholder(j["user"].get<std::string>(),   user_message);

--- a/samples/genie/c++/Service/src/GenieAPIService/src/model/def.h
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/model/def.h
@@ -157,6 +157,7 @@ struct QNNEmbeddingType : public BaseEnum
         PHI4MM,
         QWEN2_5,
         QWEN2_5_OMINI,
+        QWEN3_VL,
     };
 
     constexpr const char *to_string() const noexcept
@@ -169,6 +170,8 @@ struct QNNEmbeddingType : public BaseEnum
                 return "qwen2.5";
             case QWEN2_5_OMINI:
                 return "qwen2.5-omini";
+            case QWEN3_VL:
+                return "qwen3-vl";
             default:
                 return "none";
         }

--- a/samples/genie/c++/Service/src/GenieAPIService/src/model/model_manager.cpp
+++ b/samples/genie/c++/Service/src/GenieAPIService/src/model/model_manager.cpp
@@ -281,6 +281,24 @@ class ModelManager::QNNImpl
         }
     };
 
+    struct Qwen3VLVerifier : public EmbeddingVerifier
+    {
+        explicit Qwen3VLVerifier(const std::string &model_path)
+        {
+            embedding_type_ = QNNEmbeddingType::QWEN3_VL;
+            model_type_ = ModelType::Text;
+            embedding_file_set.emplace(ModelType{ModelType::Vision}, EmbeddingFileSet{
+                    model_path + "/vision_encoder.bin",
+                    {
+                            model_path + "/sample_inputs/position_ids_cos.raw",
+                            model_path + "/sample_inputs/position_ids_sin.raw",
+                            model_path + "/sample_inputs/window_attention_mask.raw",
+                            model_path + "/sample_inputs/full_attention_mask.raw"
+                    }
+            });
+        }
+    };
+
 public:
     static QNNEmbedding TryCreate(const std::string &model_path, const std::string &raw_path)
     {
@@ -294,6 +312,7 @@ public:
                 {{QNNEmbeddingType::PHI4MM},        [model_path]() { return PHI4Verifier(model_path).CreateIfVerified(); }},
                 {{QNNEmbeddingType::QWEN2_5},       [model_path]() { return Qwen2_5Verifier(model_path).CreateIfVerified(); }},
                 {{QNNEmbeddingType::QWEN2_5_OMINI}, [model_path]() { return Qwen2_5_OMINI_Verifier(model_path).CreateIfVerified(); }},
+                {{QNNEmbeddingType::QWEN3_VL},      [model_path]() { return Qwen3VLVerifier(model_path).CreateIfVerified(); }},
         };
 
         QNNEmbedding embedding;


### PR DESCRIPTION
﻿## Summary
Merge GenieAPIService feature work from the `developer` line into `main` via `main-fix`: adds Qwen3-VL multimodal support and related gateway / model-manager / build-integration improvements.

## Changes
- **Qwen3-VL multimodal support**: new `src/GenieAPIService/src/context/qnn/qwen3_vl/` adapter (`qwen_3_vl.cpp/.h`, `qwen3_vl_image_processor.hpp`) plus `src/GenieAPIService/src/context/torch_helper/masked_scatter.h`; wired into `src/GenieAPIService/CMakeLists.txt` and `scripts/Android.mk`.
- **QNN interface**: extended `genie_interface.cpp/.h` to support the new multimodal model dispatch path.
- **Model manager / gateway**: small behavioral updates in `model/model_manager.cpp`, `model/def.h`, `gateway/gateway/gateway.cpp/.h`, and `gateway/security/security_prompt_builder.h`.
- **Chat request handling**: adjustments in `chat_request_handler/long_text_summarizer.cpp` and `model_input_builder.h`.
- **Build/example integration**: `examples/SampleApp/CMakeLists.txt` update; `.gitignore` cleanup (`*.md`, `tools/`).

## Verification
- Windows/ARM64: full `cmake --build` Release build succeeded; `test\test_service.py --suite full` passed with `total=223, passed=205, failed=14 (all ignorable /images/generations 501), crashed=0`.
- Linux/ARM64 (WSL, QNN-only): `build_linux.sh` compiled successfully, produced valid ARM64 ELF binaries.
- Android (QNN-only): `build_android.bat` + `ndk-build` + Gradle build succeeded, produced a new `GenieAPIService.apk` including the new Qwen3-VL source.
